### PR TITLE
MGMT-23702: Update docs for AAP direct as default provider

### DIFF
--- a/architecture/aap-provisioning/README.md
+++ b/architecture/aap-provisioning/README.md
@@ -216,7 +216,7 @@ Set via `OSAC_PROVISIONING_PROVIDER` environment variable.
 | Setting | EDA Provider | AAP Direct Provider |
 |---------|-------------|---------------------|
 | **Required** | | |
-| `OSAC_PROVISIONING_PROVIDER` | `"eda"` | `"aap"` |
+| `OSAC_PROVISIONING_PROVIDER` | `"eda"` (must set explicitly) | `"aap"` (default, optional) |
 | `OSAC_COMPUTE_INSTANCE_PROVISION_WEBHOOK` | URL to EDA create endpoint | N/A |
 | `OSAC_COMPUTE_INSTANCE_DEPROVISION_WEBHOOK` | URL to EDA delete endpoint | N/A |
 | `OSAC_AAP_URL` | N/A | AAP Controller API URL (with `/api/controller`) |

--- a/architecture/aap-provisioning/README.md
+++ b/architecture/aap-provisioning/README.md
@@ -186,7 +186,7 @@ cloudkit-operator/
 **Job Tracking:**
 - Job info persisted in CR `status.jobs` array
 - Enables crash recovery and observability
-- History configurable via `CLOUDKIT_MAX_JOB_HISTORY` (default: 10)
+- History configurable via `OSAC_MAX_JOB_HISTORY` (default: 10)
 
 **Job Entry Fields:**
 - `jobID` - Job identifier
@@ -205,39 +205,39 @@ cloudkit-operator/
 
 ### Provider Selection
 
-Set via `CLOUDKIT_PROVISIONING_PROVIDER` environment variable.
+Set via `OSAC_PROVISIONING_PROVIDER` environment variable.
 
 **Values:**
-- `eda` - EDA webhook provider (default for backward compatibility)
-- `aap` - AAP Direct REST API provider
+- `aap` - AAP Direct REST API provider (default)
+- `eda` - EDA webhook provider (legacy, requires explicit opt-in)
 
 ### Configuration Comparison
 
 | Setting | EDA Provider | AAP Direct Provider |
 |---------|-------------|---------------------|
 | **Required** | | |
-| `CLOUDKIT_PROVISIONING_PROVIDER` | `"eda"` | `"aap"` |
-| `CLOUDKIT_COMPUTE_INSTANCE_PROVISION_WEBHOOK` | URL to EDA create endpoint | N/A |
-| `CLOUDKIT_COMPUTE_INSTANCE_DEPROVISION_WEBHOOK` | URL to EDA delete endpoint | N/A |
-| `CLOUDKIT_AAP_URL` | N/A | AAP Controller API URL (with `/api/controller`) |
-| `CLOUDKIT_AAP_TOKEN` | N/A | Secret reference to AAP OAuth2 token |
-| `CLOUDKIT_AAP_PROVISION_TEMPLATE` | N/A | AAP template name for provision |
-| `CLOUDKIT_AAP_DEPROVISION_TEMPLATE` | N/A | AAP template name for deprovision |
+| `OSAC_PROVISIONING_PROVIDER` | `"eda"` | `"aap"` |
+| `OSAC_COMPUTE_INSTANCE_PROVISION_WEBHOOK` | URL to EDA create endpoint | N/A |
+| `OSAC_COMPUTE_INSTANCE_DEPROVISION_WEBHOOK` | URL to EDA delete endpoint | N/A |
+| `OSAC_AAP_URL` | N/A | AAP Controller API URL (with `/api/controller`) |
+| `OSAC_AAP_TOKEN` | N/A | Secret reference to AAP OAuth2 token |
+| `OSAC_AAP_PROVISION_TEMPLATE` | N/A | AAP template name for provision |
+| `OSAC_AAP_DEPROVISION_TEMPLATE` | N/A | AAP template name for deprovision |
 | **Optional** | | |
-| `CLOUDKIT_MINIMUM_REQUEST_INTERVAL` | Min time between webhook calls (e.g., `10m`) | N/A |
-| `CLOUDKIT_AAP_STATUS_POLL_INTERVAL` | N/A | Job status poll interval (default: `30s`) |
+| `OSAC_MINIMUM_REQUEST_INTERVAL` | Min time between webhook calls (e.g., `10m`) | N/A |
+| `OSAC_AAP_STATUS_POLL_INTERVAL` | N/A | Job status poll interval (default: `30s`) |
 
-### EDA Provider Example
+### EDA Provider Example (Legacy)
 
 ```yaml
 env:
-  - name: CLOUDKIT_PROVISIONING_PROVIDER
-    value: "eda"
-  - name: CLOUDKIT_COMPUTE_INSTANCE_PROVISION_WEBHOOK
+  - name: OSAC_PROVISIONING_PROVIDER
+    value: "eda"  # Must be set explicitly; AAP direct is the default
+  - name: OSAC_COMPUTE_INSTANCE_PROVISION_WEBHOOK
     value: "http://innabox-eda-service:5000/create-compute-instance"
-  - name: CLOUDKIT_COMPUTE_INSTANCE_DEPROVISION_WEBHOOK
+  - name: OSAC_COMPUTE_INSTANCE_DEPROVISION_WEBHOOK
     value: "http://innabox-eda-service:5000/delete-compute-instance"
-  - name: CLOUDKIT_MINIMUM_REQUEST_INTERVAL
+  - name: OSAC_MINIMUM_REQUEST_INTERVAL
     value: "10m"
 ```
 
@@ -251,20 +251,19 @@ env:
 
 ```yaml
 env:
-  - name: CLOUDKIT_PROVISIONING_PROVIDER
-    value: "aap"
-  - name: CLOUDKIT_AAP_URL
+  # OSAC_PROVISIONING_PROVIDER defaults to "aap", no need to set explicitly
+  - name: OSAC_AAP_URL
     value: "https://aap.example.com/api/controller"
-  - name: CLOUDKIT_AAP_TOKEN
+  - name: OSAC_AAP_TOKEN
     valueFrom:
       secretKeyRef:
         name: aap-credentials
         key: token
-  - name: CLOUDKIT_AAP_PROVISION_TEMPLATE
+  - name: OSAC_AAP_PROVISION_TEMPLATE
     value: "innabox-create-compute-instance"
-  - name: CLOUDKIT_AAP_DEPROVISION_TEMPLATE
+  - name: OSAC_AAP_DEPROVISION_TEMPLATE
     value: "innabox-delete-compute-instance"
-  - name: CLOUDKIT_AAP_STATUS_POLL_INTERVAL
+  - name: OSAC_AAP_STATUS_POLL_INTERVAL
     value: "30s"
 ```
 
@@ -312,7 +311,7 @@ curl -X POST https://aap-url/api/v2/tokens/ \
 ### Configuration Notes
 
 **EDA:**
-- `CLOUDKIT_MINIMUM_REQUEST_INTERVAL` is client-side rate limiting, not polling
+- `OSAC_MINIMUM_REQUEST_INTERVAL` is client-side rate limiting, not polling
 - Prevents webhook flooding during reconciliation loops
 - WebhookClient caches recent requests and skips duplicates within interval
 

--- a/architecture/aap-provisioning/operations.md
+++ b/architecture/aap-provisioning/operations.md
@@ -37,11 +37,11 @@ The EDA Provider is the default and requires an EDA service deployment.
    ```yaml
    # config/manager/manager.yaml
    env:
-     - name: CLOUDKIT_PROVISIONING_PROVIDER
-       value: "eda"
-     - name: CLOUDKIT_COMPUTE_INSTANCE_PROVISION_WEBHOOK
+     - name: OSAC_PROVISIONING_PROVIDER
+       value: "eda"  # Must be set explicitly; AAP direct is the default
+     - name: OSAC_COMPUTE_INSTANCE_PROVISION_WEBHOOK
        value: "http://innabox-eda-service:5000/create-compute-instance"
-     - name: CLOUDKIT_COMPUTE_INSTANCE_DEPROVISION_WEBHOOK
+     - name: OSAC_COMPUTE_INSTANCE_DEPROVISION_WEBHOOK
        value: "http://innabox-eda-service:5000/delete-compute-instance"
    ```
 
@@ -109,20 +109,19 @@ The AAP Direct Provider communicates directly with AAP's REST API.
    ```yaml
    # config/manager/manager.yaml
    env:
-     - name: CLOUDKIT_PROVISIONING_PROVIDER
-       value: "aap"
-     - name: CLOUDKIT_AAP_URL
+     # OSAC_PROVISIONING_PROVIDER defaults to "aap", no need to set explicitly
+     - name: OSAC_AAP_URL
        value: "https://aap.example.com/api/controller"
-     - name: CLOUDKIT_AAP_TOKEN
+     - name: OSAC_AAP_TOKEN
        valueFrom:
          secretKeyRef:
            name: aap-credentials
            key: token
-     - name: CLOUDKIT_AAP_PROVISION_TEMPLATE
+     - name: OSAC_AAP_PROVISION_TEMPLATE
        value: "innabox-create-compute-instance"
-     - name: CLOUDKIT_AAP_DEPROVISION_TEMPLATE
+     - name: OSAC_AAP_DEPROVISION_TEMPLATE
        value: "innabox-delete-compute-instance"
-     - name: CLOUDKIT_AAP_STATUS_POLL_INTERVAL
+     - name: OSAC_AAP_STATUS_POLL_INTERVAL
        value: "30s"
    ```
 
@@ -229,10 +228,10 @@ Migrating from EDA to AAP Direct provides better feedback and error visibility.
    # Edit operator deployment
    kubectl edit deployment cloudkit-operator-controller-manager -n cloudkit-system
 
-   # Change environment variables:
-   # - CLOUDKIT_PROVISIONING_PROVIDER: "aap"
-   # - Add CLOUDKIT_AAP_* variables
-   # - Remove CLOUDKIT_COMPUTE_INSTANCE_*_WEBHOOK variables
+   # AAP direct is now the default, so:
+   # - Remove OSAC_PROVISIONING_PROVIDER (or set to "aap")
+   # - Add OSAC_AAP_* variables
+   # - Remove OSAC_COMPUTE_INSTANCE_*_WEBHOOK variables
    ```
 
 4. **Restart Operator:**
@@ -265,7 +264,7 @@ Migrating from EDA to AAP Direct provides better feedback and error visibility.
    kubectl get computeinstance <name> -o json | jq '.status.jobs // [] | map(select(.type == "provision")) | sort_by(.timestamp) | reverse | first'
    ```
 
-**Rollback:**
+**Rollback to EDA:**
 
 If issues occur, rollback to EDA provider:
 
@@ -274,9 +273,9 @@ If issues occur, rollback to EDA provider:
 kubectl edit deployment cloudkit-operator-controller-manager -n cloudkit-system
 
 # Change:
-# - CLOUDKIT_PROVISIONING_PROVIDER: "eda"
-# - Restore CLOUDKIT_COMPUTE_INSTANCE_*_WEBHOOK variables
-# - Remove CLOUDKIT_AAP_* variables
+# - Set OSAC_PROVISIONING_PROVIDER: "eda" (AAP direct is the default, so EDA requires explicit opt-in)
+# - Restore OSAC_COMPUTE_INSTANCE_*_WEBHOOK variables
+# - Remove OSAC_AAP_* variables
 
 # Restart operator
 kubectl rollout restart deployment/cloudkit-operator-controller-manager -n cloudkit-system
@@ -285,7 +284,7 @@ kubectl rollout restart deployment/cloudkit-operator-controller-manager -n cloud
 **Post-Migration:**
 - Update playbooks to remove annotation-based signaling if desired
 - Monitor AAP API load (polling can increase API calls)
-- Adjust `CLOUDKIT_AAP_STATUS_POLL_INTERVAL` if needed (30s-60s recommended)
+- Adjust `OSAC_AAP_STATUS_POLL_INTERVAL` if needed (30s-60s recommended)
 
 ## Monitoring and Observability
 

--- a/architecture/aap-provisioning/operations.md
+++ b/architecture/aap-provisioning/operations.md
@@ -13,7 +13,7 @@ For architecture details, see [README.md](README.md).
 
 ## Deploying with EDA Provider
 
-The EDA Provider is the default and requires an EDA service deployment.
+The EDA Provider is legacy and requires an EDA service deployment. It must be explicitly enabled by setting `OSAC_PROVISIONING_PROVIDER=eda`.
 
 **Prerequisites:**
 - EDA service deployed and accessible from cloudkit-operator

--- a/architecture/aap-provisioning/testing.md
+++ b/architecture/aap-provisioning/testing.md
@@ -182,7 +182,7 @@ This scenario verifies the EDA provider still works as expected.
 ```bash
 # 1. Ensure operator is configured for EDA provider
 kubectl get deployment cloudkit-operator-controller-manager -n cloudkit-system \
-  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="CLOUDKIT_PROVISIONING_PROVIDER")].value}'
+  -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="OSAC_PROVISIONING_PROVIDER")].value}'
 # Expected: "eda"
 
 # 2. Create ComputeInstance

--- a/architecture/aap-provisioning/troubleshooting.md
+++ b/architecture/aap-provisioning/troubleshooting.md
@@ -30,7 +30,7 @@ For architecture details, see [README.md](README.md).
 | Template not found | Error: "Template 'foo' not found" | Template name mismatch or template doesn't exist | List templates: `curl -H "Authorization: Bearer $TOKEN" $AAP_URL/job_templates/`. Verify `OSAC_AAP_PROVISION_TEMPLATE` matches AAP template name exactly (case-sensitive). |
 | Cancellation not allowed | Error: "405 Method Not Allowed" when canceling | Job already in terminal state | Job reached terminal state between check and cancel. Operator proceeds with deprovision. This is normal and not an error. |
 | SSL certificate error | Error: "x509: certificate signed by unknown authority" | AAP uses self-signed certificate or custom CA | Add CA certificate to operator deployment. Mount CA cert as volume and set `SSL_CERT_FILE` environment variable. Or disable SSL verification (not recommended for production). |
-| Poll interval too aggressive | AAP API rate limiting errors | Poll interval set too low | Increase `OSAC_AAP_STATUS_POLL_INTERVAL` to 30s or 60s. Monitor AAP API load. |
+| Poll interval too aggressive | AAP API rate-limiting errors | Poll interval set too low | Increase `OSAC_AAP_STATUS_POLL_INTERVAL` to 30s or 60s. Monitor AAP API load. |
 
 ## Debugging Commands
 

--- a/architecture/aap-provisioning/troubleshooting.md
+++ b/architecture/aap-provisioning/troubleshooting.md
@@ -27,10 +27,10 @@ For architecture details, see [README.md](README.md).
 |-------|----------|------------|----------|
 | Authentication failure | Error: "401 Unauthorized" | Invalid or expired AAP token | Verify AAP token in secret: `kubectl get secret aap-credentials -o jsonpath='{.data.token}' \| base64 -d`. Test token with curl: `curl -H "Authorization: Bearer $TOKEN" $AAP_URL/ping/`. Regenerate token if expired. |
 | Job not found | Error: "404 Not Found" when polling job | AAP purges old jobs based on retention policy | AAP automatically purges completed jobs after retention period. Operator treats 404 as terminal state and proceeds. Adjust AAP job retention if needed. |
-| Template not found | Error: "Template 'foo' not found" | Template name mismatch or template doesn't exist | List templates: `curl -H "Authorization: Bearer $TOKEN" $AAP_URL/job_templates/`. Verify `CLOUDKIT_AAP_PROVISION_TEMPLATE` matches AAP template name exactly (case-sensitive). |
+| Template not found | Error: "Template 'foo' not found" | Template name mismatch or template doesn't exist | List templates: `curl -H "Authorization: Bearer $TOKEN" $AAP_URL/job_templates/`. Verify `OSAC_AAP_PROVISION_TEMPLATE` matches AAP template name exactly (case-sensitive). |
 | Cancellation not allowed | Error: "405 Method Not Allowed" when canceling | Job already in terminal state | Job reached terminal state between check and cancel. Operator proceeds with deprovision. This is normal and not an error. |
 | SSL certificate error | Error: "x509: certificate signed by unknown authority" | AAP uses self-signed certificate or custom CA | Add CA certificate to operator deployment. Mount CA cert as volume and set `SSL_CERT_FILE` environment variable. Or disable SSL verification (not recommended for production). |
-| Poll interval too aggressive | AAP API rate limiting errors | Poll interval set too low | Increase `CLOUDKIT_AAP_STATUS_POLL_INTERVAL` to 30s or 60s. Monitor AAP API load. |
+| Poll interval too aggressive | AAP API rate limiting errors | Poll interval set too low | Increase `OSAC_AAP_STATUS_POLL_INTERVAL` to 30s or 60s. Monitor AAP API load. |
 
 ## Debugging Commands
 


### PR DESCRIPTION
## Summary
- Rename env var prefix from `CLOUDKIT_` to `OSAC_` to match the operator
- Update default provider from EDA to AAP direct
- Mark EDA provider as legacy (requires explicit opt-in via `OSAC_PROVISIONING_PROVIDER=eda`)
- Update examples and rollback instructions

Companion to [osac-operator#164](https://github.com/osac-project/osac-operator/pull/164).

## Jira
- [MGMT-23702](https://redhat.atlassian.net/browse/MGMT-23702)

Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Renamed provisioning environment variables from CLOUDKIT_* to OSAC_* across docs and examples.
  * Clarified defaults: AAP is now the default provider; EDA is legacy and requires explicit opt-in.
  * Updated migration, rollback (to EDA), testing checks, and troubleshooting guidance to reference OSAC_* variable names and updated poll/interval variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->