### PR TITLE
MGMT-23846: renames fulfillment-cli to osac in docs

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -97,7 +97,7 @@ The Fulfillment Service exists as an API layer for several reasons:
 * Additionally, Namespace-based RBAC in k8s is not sufficient for the level of tenant separation required.
 * Multiple Management Clusters may exist in a deployment as discussed above, and this layer enables topology awareness and the ability to schedule requests onto different Management Clusters as appropriate.
 
-The Fulfillment CLI integrates with this API; service providers may also
+The `osac` CLI integrates with this API; service providers may also
 integrate their own UIs with this API.
 
 ### O-SAC Controller
@@ -188,7 +188,7 @@ to identify the user and tenant.
 ### User Interfaces
 
 OSAC includes [a command-line
-utility](https://github.com/innabox/fulfillment-cli) that can be used to
+utility](https://github.com/osac-project/fulfillment-service) that can be used to
 interact with the API.
 
 OSAC may also include a web UI that can be used for demos or proofs of concept.

--- a/architecture/aap-provisioning/diagrams/component-simple.puml
+++ b/architecture/aap-provisioning/diagrams/component-simple.puml
@@ -32,7 +32,7 @@ skinparam note {
 }
 
 rectangle "User Interface" #B3E5FC {
-    component [fulfillment-cli] as CLI #81D4FA
+    component [osac] as CLI #81D4FA
 }
 
 rectangle "Control Plane" #C5E1A5 {

--- a/architecture/aap-provisioning/diagrams/sequence-aap-direct-creation.puml
+++ b/architecture/aap-provisioning/diagrams/sequence-aap-direct-creation.puml
@@ -9,7 +9,7 @@ skinparam sequenceMessageAlign center
 skinparam maxMessageSize 150
 
 actor User
-participant "fulfillment-cli" as CLI
+participant "osac" as CLI
 participant "fulfillment-service" as Service
 participant "Kubernetes API" as K8s
 participant "cloudkit-operator" as Operator

--- a/architecture/aap-provisioning/diagrams/sequence-aap-direct-deletion.puml
+++ b/architecture/aap-provisioning/diagrams/sequence-aap-direct-deletion.puml
@@ -9,7 +9,7 @@ skinparam sequenceMessageAlign center
 skinparam maxMessageSize 150
 
 actor User
-participant "fulfillment-cli" as CLI
+participant "osac" as CLI
 participant "fulfillment-service" as Service
 participant "Kubernetes API" as K8s
 participant "cloudkit-operator" as Operator

--- a/architecture/aap-provisioning/diagrams/sequence-eda.puml
+++ b/architecture/aap-provisioning/diagrams/sequence-eda.puml
@@ -8,7 +8,7 @@ skinparam backgroundColor white
 skinparam sequenceMessageAlign center
 
 actor User
-participant "fulfillment-cli" as CLI
+participant "osac" as CLI
 participant "fulfillment-service" as Service
 participant "Kubernetes API" as K8s
 participant "cloudkit-operator" as Operator

--- a/guides/developer/tenant-setup.md
+++ b/guides/developer/tenant-setup.md
@@ -436,7 +436,7 @@ namespace.
 
 The `osac.openshift.io/tenant` annotation must match the Tenant CR name exactly.
 
-When using **fulfillment-cli** or other tooling that authenticates with a **service account
+When using **osac** or other tooling that authenticates with a **service account
 token**, the effective tenant name used during provisioning (for example
 `spec.tenantReference.name` on the ComputeInstance) must match the Tenant CR you expect.
 A token from the **tenant namespace** typically yields that tenant name; a token from the


### PR DESCRIPTION
## Summary
- Updates architecture README CLI reference and GitHub link
- Renames fulfillment-cli to osac in 4 PlantUML diagrams
- Updates tenant setup guide CLI references