### PR TITLE
OSAC-497: Fix overlay graph NAT rules layout

### DIFF
--- a/features/netris-caas-networking.md
+++ b/features/netris-caas-networking.md
@@ -89,11 +89,13 @@ The SoftGate is the gateway between VPCs and the internet.
 graph TB
     internet((Internet))
 
-    mgmt_snat[Mgmt SNAT]
-    mgmt_api_dnat[Mgmt API DNAT :6443]
-    hosted_api_dnat[Hosted Cluster API DNAT :6443]
-    cluster_snat[Cluster SNAT]
-    ingress_dnat[Hosted Cluster Ingress DNAT :80/:443]
+    subgraph softgate [SoftGate]
+        mgmt_snat[Mgmt SNAT]
+        mgmt_api_dnat[Mgmt API DNAT :6443]
+        hosted_api_dnat[Hosted Cluster API DNAT :6443]
+        cluster_snat[Cluster SNAT]
+        ingress_dnat[Hosted Cluster Ingress DNAT :80/:443]
+    end
 
     subgraph mgmt_vpc [Management VPC]
         mgmt_gw[Anycast Gateway]


### PR DESCRIPTION
## Summary
- Wraps the NAT rule nodes (SNAT/DNAT) inside a SoftGate subgraph in the overlay diagram
- Fixes the disconnected lines between Internet and the NAT nodes caused by the ELK renderer spreading them too wide