### PR TITLE
OSAC-828/691: add PublicIP developer guide and architecture doc

### DIFF
--- a/architecture/README.md
+++ b/architecture/README.md
@@ -166,6 +166,7 @@ Details of specific fulfillment types are specified in the following sections.
 * [Cluster Fulfillment](cluster-fulfillment.md)
 * [Bare Metal Server Fulfillment](bm-server-fulfillment.md)
 * [VM Fulfillment](vm-fulfillment.md)
+* [PublicIP Networking](publicip-networking.md)
 
 ### Integration Patterns
 
@@ -238,8 +239,10 @@ node in the cluster.
 
 ### Networking
 
-Isolated networks are an essential element in any multi-tenant cloud. A proposal
-is in progress, and details will be added in this repo upon acceptance.
+Isolated networks are an essential element in any multi-tenant cloud. See the
+[Networking API enhancement proposal](https://github.com/osac-project/enhancement-proposals/tree/main/enhancements/networking)
+for the full design, and [PublicIP Networking](publicip-networking.md) for the
+public IP architecture.
 
 ### Inventory
 

--- a/architecture/publicip-networking.md
+++ b/architecture/publicip-networking.md
@@ -300,13 +300,23 @@ The PublicIP workflow involves several OSAC components working together:
                           Feedback path (status reporting)
 ```
 
-**Forward path:** The osac CLI sends a request to the fulfillment-service, which
-persists it and streams events to the fulfillment-controller. The controller
-reconciles API resources into Kubernetes CRs on the target cluster. The
-osac-operator watches those CRs and launches AAP jobs to configure MetalLB
-Services and IPAddressPools.
+**Forward path (provisioning):**
 
-**Feedback path:** The feedback-controller watches CR status on the workload
-cluster (phase transitions, allocated addresses) and reports changes back to the
-fulfillment-service via gRPC Signal RPCs. This closes the control loop, allowing
-the API to reflect the actual state of resources on the cluster.
+1. **Tenant/admin** uses the osac CLI (or REST/gRPC API) to create PublicIP
+   resources.
+2. **fulfillment-service** persists the resource in PostgreSQL and streams
+   events to the fulfillment-controller.
+3. **fulfillment-controller** reconciles API resources into Kubernetes custom
+   resources (CRs) on the target cluster.
+4. **osac-operator** watches the CRs and launches Ansible Automation Platform
+   (AAP) jobs for the actual network configuration.
+5. **AAP roles** create and manage MetalLB IPAddressPools, L2Advertisements,
+   and LoadBalancer Services on the target cluster.
+6. **MetalLB** advertises the allocated IPs via ARP and works with kube-proxy
+   to route traffic to the correct VM pod.
+
+**Feedback path (status reporting):**
+
+7. **feedback-controller** watches CR status on the workload cluster (phase
+   transitions, allocated addresses) and reports changes back to the
+   fulfillment-service via gRPC Signal RPCs, closing the control loop.

--- a/architecture/publicip-networking.md
+++ b/architecture/publicip-networking.md
@@ -275,70 +275,38 @@ The attach/detach mechanism uses a "service swap" pattern:
 The PublicIP workflow involves several OSAC components working together:
 
 ```
-  +------------------+     gRPC/REST     +---------------------+
-  |  osac CLI        | ----------------> | fulfillment-service |
-  |  (tenant/admin)  |                   |   gRPC server       |
-  +------------------+                   |   REST gateway      |
-                                         |   PostgreSQL        |
-                                         +----------+----------+
-                                                    |
-                                           stream events
-                                                    |
-                                                    v
-                                         +---------------------+
-                                         | fulfillment-        |
-                                         | controller          |
-                                         |   (reconciler)      |
-                                         +----------+----------+
-                                                    |
-                                           creates K8s CRs
-                                                    |
-                                                    v
-                                         +---------------------+
-                                         | osac-operator       |
-                                         |   (controller-      |
-                                         |    runtime)          |
-                                         +----------+----------+
-                                                    |
-                                           launches AAP jobs
-                                                    |
-                                                    v
-                                         +---------------------+
-                                         | AAP (Ansible)       |
-                                         |                     |
-                                         |  Pool provisioning: |
-                                         |   allocate-public-ip|
-                                         |                     |
-                                         |  IP attachment:     |
-                                         |   attach-public-ip  |
-                                         |   detach-public-ip  |
-                                         |                     |
-                                         |  IP release:        |
-                                         |   deallocate-       |
-                                         |     public-ip       |
-                                         +----------+----------+
-                                                    |
-                                           configures MetalLB
-                                           Services + IPPools
-                                                    |
-                                                    v
-                                         +---------------------+
-                                         | MetalLB (L2 mode)   |
-                                         |   IPAddressPool     |
-                                         |   L2Advertisement   |
-                                         |   Speaker (ARP)     |
-                                         +---------------------+
+                          Forward path (provisioning)
+                    ─────────────────────────────────────>
+
+  +-----------+    +-------------+    +--------------+    +--------------+    +--------+
+  |  osac CLI |    | fulfillment |    | fulfillment- |    | osac-operator|    |  AAP   |
+  |           |--->| -service    |--->| controller   |--->| (controller- |--->|        |
+  | tenant or |    |             |    |              |    |  runtime)    |    | Ansible|
+  | admin     |    | gRPC/REST   |    | reconciles   |    | watches CRs, |    | roles  |
+  |           |    | PostgreSQL  |    | API objects  |    | launches AAP |    |        |
+  +-----------+    +------+------+    | to K8s CRs   |    | jobs         |    +---+----+
+                          ^           +--------------+    +--------------+        |
+                          |                                                      |
+                   gRPC Signal                                          configures MetalLB
+                   (status updates)                                     Services + IPPools
+                          |                                                      |
+                   +------+-------+                                     +--------+--------+
+                   | feedback-    |       watches CR status              | MetalLB         |
+                   | controller  |<─────────────────────────────────────| (L2 mode)       |
+                   |             |       on workload cluster             | IPAddressPool   |
+                   +-------------+                                      | L2Advertisement |
+                                                                        | Speaker (ARP)   |
+                          <──────────────────────────────────────        +-----------------+
+                          Feedback path (status reporting)
 ```
 
-1. **Tenant/admin** uses the osac CLI (or REST/gRPC API) to create PublicIP
-   resources.
-2. **fulfillment-service** persists the resource in PostgreSQL and streams
-   events to the fulfillment-controller.
-3. **fulfillment-controller** reconciles API resources into Kubernetes custom
-   resources (CRs) on the target cluster.
-4. **osac-operator** watches the CRs and launches Ansible Automation Platform
-   (AAP) jobs for the actual network configuration.
-5. **AAP roles** create and manage MetalLB IPAddressPools, L2Advertisements,
-   and LoadBalancer Services on the target cluster.
-6. **MetalLB** advertises the allocated IPs via ARP and works with kube-proxy
-   to route traffic to the correct VM pod.
+**Forward path:** The osac CLI sends a request to the fulfillment-service, which
+persists it and streams events to the fulfillment-controller. The controller
+reconciles API resources into Kubernetes CRs on the target cluster. The
+osac-operator watches those CRs and launches AAP jobs to configure MetalLB
+Services and IPAddressPools.
+
+**Feedback path:** The feedback-controller watches CR status on the workload
+cluster (phase transitions, allocated addresses) and reports changes back to the
+fulfillment-service via gRPC Signal RPCs. This closes the control loop, allowing
+the API to reflect the actual state of resources on the cluster.

--- a/architecture/publicip-networking.md
+++ b/architecture/publicip-networking.md
@@ -275,29 +275,29 @@ The attach/detach mechanism uses a "service swap" pattern:
 The PublicIP workflow involves several OSAC components working together:
 
 ```
-                          Forward path (provisioning)
-                    ─────────────────────────────────────>
+                              Forward path (provisioning)
+                 ────────────────────────────────────────────────>
 
-  +-----------+    +-------------+    +--------------+    +--------------+    +--------+
-  |  osac CLI |    | fulfillment |    | fulfillment- |    | osac-operator|    |  AAP   |
-  |           |--->| -service    |--->| controller   |--->| (controller- |--->|        |
-  | tenant or |    |             |    |              |    |  runtime)    |    | Ansible|
-  | admin     |    | gRPC/REST   |    | reconciles   |    | watches CRs, |    | roles  |
-  |           |    | PostgreSQL  |    | API objects  |    | launches AAP |    |        |
-  +-----------+    +------+------+    | to K8s CRs   |    | jobs         |    +---+----+
-                          ^           +--------------+    +--------------+        |
-                          |                                                      |
-                   gRPC Signal                                          configures MetalLB
-                   (status updates)                                     Services + IPPools
-                          |                                                      |
-                   +------+-------+                                     +--------+--------+
-                   | feedback-    |       watches CR status              | MetalLB         |
-                   | controller  |<─────────────────────────────────────| (L2 mode)       |
-                   |             |       on workload cluster             | IPAddressPool   |
-                   +-------------+                                      | L2Advertisement |
-                                                                        | Speaker (ARP)   |
-                          <──────────────────────────────────────        +-----------------+
-                          Feedback path (status reporting)
+  +-----------+  +-----------+  +------------+  +------------+  +------------+
+  | osac CLI  |  | fulfill-  |  | fulfill-   |  | osac-      |  | AAP        |
+  |           |->| ment-     |->| ment-      |->| operator   |->|            |
+  | tenant or |  | service   |  | controller |  |            |  | Ansible    |
+  | admin     |  |           |  |            |  | watches    |  | roles      |
+  |           |  | gRPC/REST |  | reconciles |  | CRs,       |  |            |
+  +-----------+  | PostgreSQL|  | API to CRs |  | launches   |  +------+-----+
+                 +-----+-----+  +------------+  | AAP jobs   |         |
+                       ^                         +------------+   configures
+                       |                                          MetalLB Svcs
+                 gRPC Signal                                      + IPPools
+                 (status updates)                                       |
+                       |                                          +-----+------+
+                 +-----+------+      watches CR status            | MetalLB    |
+                 | feedback-  |<----------------------------------| (L2 mode)  |
+                 | controller |      on workload cluster          |            |
+                 +------------+                                   +------------+
+
+                 <────────────────────────────────────────────────
+                              Feedback path (status reporting)
 ```
 
 **Forward path (provisioning):**

--- a/architecture/publicip-networking.md
+++ b/architecture/publicip-networking.md
@@ -99,35 +99,32 @@ PublicIP networking uses three resource types with a clear separation between
 provider-managed infrastructure and tenant self-service:
 
 ```
-  Cloud Provider Admin                    Tenant User
-  (private API)                           (public API)
-                                  
-  +---------------------------+           
-  | PublicIPPool              |           
-  |   CIDRs: 203.0.113.0/28  |           
-  |   IP family: IPv4         |           
-  |   State: Ready            |           
-  |   Available: 12           |           
-  +---------------------------+           
-           |                              
-           |  allocate from pool          
-           v                              
-                                   +---------------------------+
-                                   | PublicIP                  |
-                                   |   Pool: <pool-id>         |
-                                   |   Address: 203.0.113.10   |
-                                   |   State: Allocated        |
-                                   |   Attached: false         |
-                                   +---------------------------+
-                                            |
-                                            |  bind to instance
-                                            v
-                                   +---------------------------+
-                                   | PublicIPAttachment        |
-                                   |   PublicIP: <ip-id>       |
-                                   |   Target: <instance-id>   |
-                                   |   State: Ready            |
-                                   +---------------------------+
+  +-------------------------------+
+  | PublicIPPool                  |  <-- Cloud Provider Admin (private API)
+  |   CIDRs: 203.0.113.0/28      |
+  |   IP family: IPv4             |
+  |   State: Ready                |
+  |   Available: 12               |
+  +-------------------------------+
+               |
+               |  tenant allocates from pool
+               v
+  +-------------------------------+
+  | PublicIP                      |  <-- Tenant User (public API)
+  |   Pool: <pool-id>             |
+  |   Address: 203.0.113.10       |
+  |   State: Allocated            |
+  |   Attached: false             |
+  +-------------------------------+
+               |
+               |  tenant binds to instance
+               v
+  +-------------------------------+
+  | PublicIPAttachment            |  <-- Tenant User (public API)
+  |   PublicIP: <ip-id>           |
+  |   Target: <instance-id>       |
+  |   State: Ready                |
+  +-------------------------------+
 ```
 
 ### PublicIPPool

--- a/architecture/publicip-networking.md
+++ b/architecture/publicip-networking.md
@@ -33,16 +33,16 @@ route to the pod network and cannot reach the VM:
        |  10.128.0.81:22?        |  (OVN overlay)      |
        |                         |  10.128.0.0/14      |
        X--- NO ----------X       |                     |
-                                 |  +---------------+  |
-       The pod network is an     |  | virt-launcher  |  |
-       overlay. No route exists  |  | pod            |  |
-       from the external         |  |  10.128.0.81   |  |
-       network.                  |  |                 |  |
-                                 |  |  +-----------+ |  |
-                                 |  |  | KubeVirt  | |  |
-                                 |  |  | VM        | |  |
-                                 |  |  +-----------+ |  |
-                                 |  +---------------+  |
+                                 |  +----------------+ |
+       The pod network is an     |  | virt-launcher  | |
+       overlay. No route exists  |  | pod            | |
+       from the external         |  |  10.128.0.81   | |
+       network.                  |  |                | |
+                                 |  |  +-----------+ | |
+                                 |  |  | KubeVirt  | | |
+                                 |  |  | VM        | | |
+                                 |  |  +-----------+ | |
+                                 |  +----------------+ |
                                  +---------------------+
 ```
 
@@ -75,14 +75,14 @@ the public IP is routed through the Kubernetes Service to the VM pod:
        |                         |       | DNAT        |
        |                         |       v             |
        |                         |  +---------------+  |
-       |                         |  | virt-launcher  |  |
-       |                         |  | pod            |  |
-       |                         |  |  10.128.0.81   |  |
-       |                         |  |                 |  |
-       |                         |  |  +-----------+ |  |
-       |  SSH Connected!         |  |  | KubeVirt  | |  |
-       |<--- TCP SYN-ACK -------|  |  | VM        | |  |
-       |                         |  |  +-----------+ |  |
+       |                         |  | virt-launcher  | |
+       |                         |  | pod            | |
+       |                         |  |  10.128.0.81   | |
+       |                         |  |                | |
+       |                         |  |  +-----------+ | |
+       |  SSH Connected!         |  |  | KubeVirt  | | |
+       |<--- TCP SYN-ACK --------|  |  | VM        | | |
+       |                         |  |  +-----------+ | |
        |                         |  +---------------+  |
        |                         +---------------------+
 ```
@@ -99,32 +99,32 @@ PublicIP networking uses three resource types with a clear separation between
 provider-managed infrastructure and tenant self-service:
 
 ```
-  +-------------------------------+
-  | PublicIPPool                  |  <-- Cloud Provider Admin (private API)
-  |   CIDRs: 203.0.113.0/28      |
-  |   IP family: IPv4             |
-  |   State: Ready                |
-  |   Available: 12               |
-  +-------------------------------+
-               |
-               |  tenant allocates from pool
-               v
-  +-------------------------------+
-  | PublicIP                      |  <-- Tenant User (public API)
-  |   Pool: <pool-id>             |
-  |   Address: 203.0.113.10       |
-  |   State: Allocated            |
-  |   Attached: false             |
-  +-------------------------------+
-               |
-               |  tenant binds to instance
-               v
-  +-------------------------------+
-  | PublicIPAttachment            |  <-- Tenant User (public API)
-  |   PublicIP: <ip-id>           |
-  |   Target: <instance-id>       |
-  |   State: Ready                |
-  +-------------------------------+
+  +-------------------------------------+
+  | PublicIPPool                        |  <-- Cloud Provider Admin (private API)
+  |   CIDRs: 203.0.113.0/28             |
+  |   IP family: IPv4                   |
+  |   State: Ready                      |
+  |   Available: 12                     |
+  +-------------------------------------+
+                     |
+                     |  tenant allocates from pool
+                     v
+  +-------------------------------------+
+  | PublicIP                            |  <-- Tenant User (public API)
+  |   Pool: <pool-name>                 |
+  |   Address: 203.0.113.10             |
+  |   State: Allocated                  |
+  |   Attached: false                   |
+  +-------------------------------------+
+                     |
+                     |  tenant binds to ComputeInstance
+                     v
+  +-------------------------------------+
+  | PublicIPAttachment                  |  <-- Tenant User (public API)
+  |   PublicIP: <publicip-name>         |
+  |   Target: <computeinstance-name>    |
+  |   State: Ready                      |
+  +-------------------------------------+
 ```
 
 ### PublicIPPool
@@ -174,7 +174,7 @@ responsible for that stage:
 
 ```
   Phase 1: Pool Provisioning (Cloud Provider Admin)
-  +---------------------------------------------------+
+  +----------------------------------------------------+
   |  PublicIPPool                                      |
   |    CIDRs: 203.0.113.0/28                           |
   |    State: Pending -> Ready                         |
@@ -182,38 +182,38 @@ responsible for that stage:
   |  The system creates a MetalLB IPAddressPool on     |
   |  the target cluster and configures L2              |
   |  advertisement for the CIDR ranges.                |
-  +---------------------------------------------------+
+  +----------------------------------------------------+
        |
        |  Tenant allocates from pool
        v
   Phase 2: IP Allocation (Tenant User)
-  +---------------------------------------------------+
+  +----------------------------------------------------+
   |  PublicIP                                          |
-  |    Address: 203.0.113.10                            |
+  |    Address: 203.0.113.10                           |
   |    State: Pending -> Allocated                     |
   |    Attached: false                                 |
   |                                                    |
   |  A "parking" LoadBalancer Service is created with  |
   |  an empty selector. This reserves the IP via ARP   |
   |  but does not route traffic to any workload.       |
-  +---------------------------------------------------+
+  +----------------------------------------------------+
        |
        |  Tenant creates PublicIPAttachment
        v
   Phase 3: Attachment (Tenant User)
-  +---------------------------------------------------+
+  +----------------------------------------------------+
   |  PublicIPAttachment                                |
-  |    PublicIP: <ip-id>                               |
-  |    ComputeInstance: <instance-id>                   |
+  |    PublicIP: <publicip-name>                       |
+  |    ComputeInstance: <computeinstance-name>         |
   |    State: Pending -> Ready                         |
   |                                                    |
-  |  The system moves the Service into the VM's        |
-  |  namespace with a selector matching the VM pod.    |
-  |  MetalLB advertises the IP and kube-proxy DNATs    |
-  |  traffic to the pod.                               |
+  |  The system moves the Service into the             |
+  |  ComputeInstance's namespace with a selector       |
+  |  matching the VM pod. MetalLB advertises the IP    |
+  |  and kube-proxy DNATs traffic to the pod.          |
   |                                                    |
   |  PublicIP.attached = true                          |
-  +---------------------------------------------------+
+  +----------------------------------------------------+
 ```
 
 ### Detach and release

--- a/architecture/publicip-networking.md
+++ b/architecture/publicip-networking.md
@@ -1,0 +1,347 @@
+# PublicIP Networking
+
+This document describes how OSAC provides publicly routable IP addresses for
+ComputeInstances (KubeVirt VMs). It covers the problem being solved, the
+resource model, the traffic flow, and the system components involved.
+
+For a step-by-step usage guide, see
+[Assigning a Public IP to a ComputeInstance](../guides/developer/publicip-guide.md).
+
+## Contents
+
+- [Problem: VMs are isolated by default](#problem-vms-are-isolated-by-default)
+- [Solution: PublicIP + MetalLB L2](#solution-publicip--metallb-l2)
+- [Resource model](#resource-model)
+- [Lifecycle](#lifecycle)
+- [Traffic flow](#traffic-flow)
+- [System architecture](#system-architecture)
+
+---
+
+## Problem: VMs are isolated by default
+
+KubeVirt VMs run as pods on an OVN overlay network. They receive pod IPs (for
+example, 10.128.x.x) that are internal to the cluster. Masquerade networking
+allows VMs to initiate outbound connections, but external clients have no
+route to the pod network and cannot reach the VM:
+
+```
+  External Client                    OpenShift Cluster
+                                 +---------------------+
+       |                         |                     |
+       |  Can I reach            |  Pod Network        |
+       |  10.128.0.81:22?        |  (OVN overlay)      |
+       |                         |  10.128.0.0/14      |
+       X--- NO ----------X       |                     |
+                                 |  +---------------+  |
+       The pod network is an     |  | virt-launcher  |  |
+       overlay. No route exists  |  | pod            |  |
+       from the external         |  |  10.128.0.81   |  |
+       network.                  |  |                 |  |
+                                 |  |  +-----------+ |  |
+                                 |  |  | KubeVirt  | |  |
+                                 |  |  | VM        | |  |
+                                 |  |  +-----------+ |  |
+                                 |  +---------------+  |
+                                 +---------------------+
+```
+
+Use cases that require inbound connectivity (SSH access, hosting a web
+service, accepting API calls) need a routable address on the physical network.
+
+---
+
+## Solution: PublicIP + MetalLB L2
+
+OSAC provisions a MetalLB LoadBalancer Service that advertises a public IP
+address on the physical network via ARP (Layer 2 mode). External traffic to
+the public IP is routed through the Kubernetes Service to the VM pod:
+
+```
+  External Client                    OpenShift Cluster
+                                 +---------------------+
+       |                         |                     |
+       |  ssh user@              |  MetalLB Speaker    |
+       |  203.0.113.10           |  (L2 mode)          |
+       |                         |                     |
+       +-------- ARP ----------->|  "203.0.113.10      |
+       |  "Who has               |   is at MAC         |
+       |   203.0.113.10?"        |   aa:bb:cc:dd"      |
+       |                         |                     |
+       +--- TCP SYN ------------>|  LoadBalancer Svc   |
+       |                         |  203.0.113.10       |
+       |                         |       |             |
+       |                         |       | kube-proxy  |
+       |                         |       | DNAT        |
+       |                         |       v             |
+       |                         |  +---------------+  |
+       |                         |  | virt-launcher  |  |
+       |                         |  | pod            |  |
+       |                         |  |  10.128.0.81   |  |
+       |                         |  |                 |  |
+       |                         |  |  +-----------+ |  |
+       |  SSH Connected!         |  |  | KubeVirt  | |  |
+       |<--- TCP SYN-ACK -------|  |  | VM        | |  |
+       |                         |  |  +-----------+ |  |
+       |                         |  +---------------+  |
+       |                         +---------------------+
+```
+
+The MetalLB Speaker responds to ARP requests for the public IP, claiming it
+on the local network segment. Once ARP resolves, the Kubernetes Service
+receives the traffic and kube-proxy DNATs it to the VM's pod IP.
+
+---
+
+## Resource model
+
+PublicIP networking uses three resource types with a clear separation between
+provider-managed infrastructure and tenant self-service:
+
+```
+  Cloud Provider Admin                    Tenant User
+  (private API)                           (public API)
+                                  
+  +---------------------------+           
+  | PublicIPPool              |           
+  |   CIDRs: 203.0.113.0/28  |           
+  |   IP family: IPv4         |           
+  |   State: Ready            |           
+  |   Available: 12           |           
+  +---------------------------+           
+           |                              
+           |  allocate from pool          
+           v                              
+                                   +---------------------------+
+                                   | PublicIP                  |
+                                   |   Pool: <pool-id>         |
+                                   |   Address: 203.0.113.10   |
+                                   |   State: Allocated        |
+                                   |   Attached: false         |
+                                   +---------------------------+
+                                            |
+                                            |  bind to instance
+                                            v
+                                   +---------------------------+
+                                   | PublicIPAttachment        |
+                                   |   PublicIP: <ip-id>       |
+                                   |   Target: <instance-id>   |
+                                   |   State: Ready            |
+                                   +---------------------------+
+```
+
+### PublicIPPool
+
+A range of routable IP addresses provisioned by the cloud provider.
+
+- Created via the **private (admin) API** only.
+- Defines one or more CIDR ranges and an IP family (IPv4 or IPv6). A single
+  pool cannot mix address families.
+- Tracks capacity: total addresses, currently allocated, and available.
+- CIDRs and IP family are immutable after creation.
+- Tenants can list and inspect pools via the public API but cannot create,
+  modify, or delete them.
+
+### PublicIP
+
+A single routable address allocated from a PublicIPPool.
+
+- Created by **tenants** via the public API.
+- The pool assignment is required at creation time and immutable.
+- Lifecycle: `Pending` (waiting for address allocation) then `Allocated`
+  (address assigned and reserved).
+- Independent of any ComputeInstance. A PublicIP persists until explicitly
+  deleted, allowing tenants to reserve and reassign addresses.
+- Cannot be deleted while attached. The attachment must be removed first.
+
+### PublicIPAttachment
+
+The binding between a PublicIP and a target resource (currently
+ComputeInstance, with future support for other resource types).
+
+- Created by **tenants** via the public API.
+- Both the PublicIP reference and the target are immutable. To change the
+  target, delete the attachment and create a new one.
+- Lifecycle: `Pending` (attach in progress) then `Ready` (traffic routing).
+- Deleting the attachment triggers the detach workflow but does not release
+  the PublicIP.
+- One-to-one binding: each PublicIP can have at most one attachment, and each
+  ComputeInstance can have at most one PublicIPAttachment.
+
+---
+
+## Lifecycle
+
+The full lifecycle spans three phases, each managed by the resource type
+responsible for that stage:
+
+```
+  Phase 1: Pool Provisioning (Cloud Provider Admin)
+  +---------------------------------------------------+
+  |  PublicIPPool                                      |
+  |    CIDRs: 203.0.113.0/28                           |
+  |    State: Pending -> Ready                         |
+  |                                                    |
+  |  The system creates a MetalLB IPAddressPool on     |
+  |  the target cluster and configures L2              |
+  |  advertisement for the CIDR ranges.                |
+  +---------------------------------------------------+
+       |
+       |  Tenant allocates from pool
+       v
+  Phase 2: IP Allocation (Tenant User)
+  +---------------------------------------------------+
+  |  PublicIP                                          |
+  |    Address: 203.0.113.10                            |
+  |    State: Pending -> Allocated                     |
+  |    Attached: false                                 |
+  |                                                    |
+  |  A "parking" LoadBalancer Service is created with  |
+  |  an empty selector. This reserves the IP via ARP   |
+  |  but does not route traffic to any workload.       |
+  +---------------------------------------------------+
+       |
+       |  Tenant creates PublicIPAttachment
+       v
+  Phase 3: Attachment (Tenant User)
+  +---------------------------------------------------+
+  |  PublicIPAttachment                                |
+  |    PublicIP: <ip-id>                               |
+  |    ComputeInstance: <instance-id>                   |
+  |    State: Pending -> Ready                         |
+  |                                                    |
+  |  The system moves the Service into the VM's        |
+  |  namespace with a selector matching the VM pod.    |
+  |  MetalLB advertises the IP and kube-proxy DNATs    |
+  |  traffic to the pod.                               |
+  |                                                    |
+  |  PublicIP.attached = true                          |
+  +---------------------------------------------------+
+```
+
+### Detach and release
+
+Detaching reverses Phase 3: the Service is moved back to a parking namespace
+with an empty selector. The PublicIP remains `Allocated` and can be reattached
+to a different ComputeInstance.
+
+Releasing (deleting the PublicIP) reverses Phase 2: the parking Service is
+removed and the address is returned to the pool's available capacity.
+
+---
+
+## Traffic flow
+
+Once a PublicIPAttachment reaches `Ready` state, the packet path for an
+inbound connection looks like this:
+
+1. **External client** sends a packet to the public IP (e.g., 203.0.113.10).
+2. **MetalLB Speaker** responds to ARP for that address, claiming it on the
+   node's physical NIC.
+3. **kube-proxy** matches the packet to the LoadBalancer Service and DNATs it
+   to the VM's pod IP (e.g., 10.128.0.81).
+4. **OVN overlay** delivers the packet to the virt-launcher pod.
+5. **KubeVirt VM** receives the connection.
+
+Return traffic follows the reverse path. From the external client's
+perspective, the VM appears to have a stable routable address on the physical
+network.
+
+### Service swap pattern
+
+The attach/detach mechanism uses a "service swap" pattern:
+
+```
+  ALLOCATED (parking)               ATTACHED (routing)
+
+  parking namespace                  VM's namespace
+  +------------------------+        +------------------------+
+  | Service: parking-svc   |        | Service: ingress-svc   |
+  | type: LoadBalancer     |        | type: LoadBalancer     |
+  | loadBalancerIP:        |        | loadBalancerIP:        |
+  |   203.0.113.10         |        |   203.0.113.10         |
+  | selector: {}  (empty)  |  ==>   | selector:              |
+  |                        |        |   vm.kubevirt.io/name: |
+  | IP reserved via ARP    |        |     <vm-name>          |
+  | but not routed.        |        |                        |
+  +------------------------+        | Traffic routed to VM.  |
+                                    +------------------------+
+
+  Attach: delete parking-svc, create ingress-svc in VM namespace
+  Detach: delete ingress-svc, recreate parking-svc
+```
+
+---
+
+## System architecture
+
+The PublicIP workflow involves several OSAC components working together:
+
+```
+  +------------------+     gRPC/REST     +---------------------+
+  |  osac CLI        | ----------------> | fulfillment-service |
+  |  (tenant/admin)  |                   |   gRPC server       |
+  +------------------+                   |   REST gateway      |
+                                         |   PostgreSQL        |
+                                         +----------+----------+
+                                                    |
+                                           stream events
+                                                    |
+                                                    v
+                                         +---------------------+
+                                         | fulfillment-        |
+                                         | controller          |
+                                         |   (reconciler)      |
+                                         +----------+----------+
+                                                    |
+                                           creates K8s CRs
+                                                    |
+                                                    v
+                                         +---------------------+
+                                         | osac-operator       |
+                                         |   (controller-      |
+                                         |    runtime)          |
+                                         +----------+----------+
+                                                    |
+                                           launches AAP jobs
+                                                    |
+                                                    v
+                                         +---------------------+
+                                         | AAP (Ansible)       |
+                                         |                     |
+                                         |  Pool provisioning: |
+                                         |   allocate-public-ip|
+                                         |                     |
+                                         |  IP attachment:     |
+                                         |   attach-public-ip  |
+                                         |   detach-public-ip  |
+                                         |                     |
+                                         |  IP release:        |
+                                         |   deallocate-       |
+                                         |     public-ip       |
+                                         +----------+----------+
+                                                    |
+                                           configures MetalLB
+                                           Services + IPPools
+                                                    |
+                                                    v
+                                         +---------------------+
+                                         | MetalLB (L2 mode)   |
+                                         |   IPAddressPool     |
+                                         |   L2Advertisement   |
+                                         |   Speaker (ARP)     |
+                                         +---------------------+
+```
+
+1. **Tenant/admin** uses the osac CLI (or REST/gRPC API) to create PublicIP
+   resources.
+2. **fulfillment-service** persists the resource in PostgreSQL and streams
+   events to the fulfillment-controller.
+3. **fulfillment-controller** reconciles API resources into Kubernetes custom
+   resources (CRs) on the target cluster.
+4. **osac-operator** watches the CRs and launches Ansible Automation Platform
+   (AAP) jobs for the actual network configuration.
+5. **AAP roles** create and manage MetalLB IPAddressPools, L2Advertisements,
+   and LoadBalancer Services on the target cluster.
+6. **MetalLB** advertises the allocated IPs via ARP and works with kube-proxy
+   to route traffic to the correct VM pod.

--- a/features/README.md
+++ b/features/README.md
@@ -20,3 +20,10 @@ All of this adds up to an easy-to-use, on-demand solution that cloud providers c
 ## Feature Documentation
 
 * [Console Access](MGMT-22670-console-access.md) - Serial console access for compute instances
+* [Netris CaaS Networking](netris-caas-networking.md) - Network traffic flow with Netris backend
+
+## Developer Guides
+
+* [Tenant Setup](../guides/developer/tenant-setup.md) - Create and configure a Tenant
+* [Creating a VM](../guides/developer/computeinstance-guide.md) - Create a ComputeInstance with networking
+* [Assigning a Public IP](../guides/developer/publicip-guide.md) - Allocate and attach a PublicIP to a ComputeInstance

--- a/guides/developer/publicip-guide.md
+++ b/guides/developer/publicip-guide.md
@@ -1,0 +1,186 @@
+# Assigning a Public IP to a ComputeInstance
+
+This guide walks through allocating a public IP address and attaching it to a
+running ComputeInstance so that it becomes reachable from outside the cluster.
+It covers the full lifecycle: pool discovery, IP allocation, attachment,
+detachment, and release.
+
+For background on why PublicIPs are needed and how they work under the hood,
+see the [PublicIP Networking Architecture](../../architecture/publicip-networking.md).
+
+## Contents
+
+- [Overview](#overview)
+- [Who does what](#who-does-what)
+- [Prerequisites](#prerequisites)
+- [Step 1: Find an available PublicIPPool](#step-1-find-an-available-publicippool)
+- [Step 2: Allocate a PublicIP](#step-2-allocate-a-publicip)
+- [Step 3: Attach the PublicIP to a ComputeInstance](#step-3-attach-the-publicip-to-a-computeinstance)
+- [Step 4: Verify connectivity](#step-4-verify-connectivity)
+- [Detaching and releasing](#detaching-and-releasing)
+
+---
+
+## Overview
+
+ComputeInstances (VMs) in OSAC use an overlay pod network. By default they can
+initiate outbound connections but are not reachable from outside the cluster.
+A **PublicIP** gives a VM a routable address on the physical network so that
+external clients can connect to it (for example, via SSH or HTTPS).
+
+The PublicIP model uses three resource types:
+
+| Resource | Purpose | Managed by |
+|----------|---------|------------|
+| **PublicIPPool** | A range of routable IP addresses provisioned by the cloud provider | Cloud Provider Admin |
+| **PublicIP** | A single address allocated from a pool, reserved for a tenant | Tenant User |
+| **PublicIPAttachment** | Binds a PublicIP to a ComputeInstance, enabling traffic routing | Tenant User |
+
+These resources are independent of each other's lifecycle. Allocating an IP
+does not automatically attach it, and detaching does not release it. This
+lets tenants reserve addresses and reassign them between instances as needed.
+
+---
+
+## Who does what
+
+| Persona | Actions |
+|---------|---------|
+| **Cloud Provider Admin** | Creates PublicIPPools via the private admin API. Defines CIDR ranges and IP family (IPv4 or IPv6). |
+| **Tenant User** | Discovers available pools (public API). Allocates PublicIPs from a pool. Creates and deletes PublicIPAttachments to route traffic to their ComputeInstances. |
+
+Tenants cannot create or modify pools. They can only allocate IPs from pools
+that the provider has made available.
+
+---
+
+## Prerequisites
+
+- The `osac` CLI is installed and configured (API endpoint, authentication token).
+- A Tenant is in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
+- A ComputeInstance is in `RUNNING` state (see [ComputeInstance Guide](computeinstance-guide.md)).
+- At least one PublicIPPool has been created by the cloud provider.
+
+---
+
+## Step 1: Find an available PublicIPPool
+
+List the pools that are visible to your tenant:
+
+```bash
+osac get publicippool
+```
+
+The output shows each pool's IP family, CIDR ranges, and how many addresses are
+still available. Choose a pool that matches the address family you need (IPv4
+or IPv6) and has available capacity.
+
+Note the **ID** of the pool you want to use.
+
+---
+
+## Step 2: Allocate a PublicIP
+
+Allocate an address from the chosen pool:
+
+```bash
+osac create publicip \
+  --name <publicip_name> \
+  --pool <pool-id>
+```
+
+The PublicIP starts in `PENDING` state while the system reserves an address.
+Wait for it to reach `ALLOCATED`:
+
+```bash
+osac get publicip
+```
+
+Once allocated, the output shows the assigned address in the `ADDRESS` column.
+The IP is now reserved for your tenant but is not yet routing traffic to any
+resource.
+
+> **Note:** The `--pool` field is immutable. A PublicIP cannot be moved to a
+> different pool after creation. To use a different pool, delete this PublicIP
+> and create a new one.
+
+---
+
+## Step 3: Attach the PublicIP to a ComputeInstance
+
+Create a PublicIPAttachment to bind the allocated IP to a running
+ComputeInstance:
+
+```bash
+osac create publicipattachment \
+  --name <attachment_name> \
+  --public-ip <publicip-id> \
+  --compute-instance <computeinstance-id>
+```
+
+The attachment starts in `PENDING` state while the system configures network
+routing. Wait for it to reach `READY`:
+
+```bash
+osac get publicipattachment
+```
+
+When the attachment is `READY`, external clients can reach the ComputeInstance
+at the public IP address. The PublicIP's status also updates to show
+`ATTACHED: true`.
+
+> **Constraints:**
+> - Each PublicIP can have at most one attachment at a time.
+> - Each ComputeInstance can have at most one PublicIPAttachment at a time.
+> - Both fields (public IP and compute instance) are immutable. To change
+>   the target, delete the attachment and create a new one.
+
+---
+
+## Step 4: Verify connectivity
+
+Test that the ComputeInstance is reachable at the public IP address. For
+example, if the VM exposes SSH on port 22:
+
+```bash
+ssh <username>@<public-ip-address>
+```
+
+Or check with netcat:
+
+```bash
+nc -zv <public-ip-address> 22
+```
+
+---
+
+## Detaching and releasing
+
+### Detach only (keep the IP reserved)
+
+Delete the PublicIPAttachment to stop routing traffic to the ComputeInstance
+while keeping the IP address allocated:
+
+```bash
+osac delete publicipattachment <attachment-id>
+```
+
+The PublicIP remains in `ALLOCATED` state with `ATTACHED: false`. You can
+create a new PublicIPAttachment to attach it to a different ComputeInstance.
+
+### Release the IP (return it to the pool)
+
+First detach the IP if it is currently attached (a PublicIP cannot be deleted
+while attached):
+
+```bash
+osac delete publicipattachment <attachment-id>
+```
+
+Then delete the PublicIP to return the address to the pool:
+
+```bash
+osac delete publicip <publicip-id>
+```
+
+The address becomes available for other tenants to allocate.

--- a/guides/developer/publicip-guide.md
+++ b/guides/developer/publicip-guide.md
@@ -61,6 +61,10 @@ that the provider has made available.
 - A ComputeInstance is in `RUNNING` state (see [ComputeInstance Guide](computeinstance-guide.md)).
 - At least one PublicIPPool has been created by the cloud provider.
 
+> **Tip:** Wherever this guide uses a resource name (e.g., `<pool-name>`),
+> you can also use its UUID. The `osac` CLI accepts either form when
+> referencing existing resources.
+
 ---
 
 ## Step 1: Find an available PublicIPPool
@@ -75,7 +79,7 @@ The output shows each pool's IP family, CIDR ranges, and how many addresses are
 still available. Choose a pool that matches the address family you need (IPv4
 or IPv6) and has available capacity.
 
-Note the **ID** of the pool you want to use.
+Note the **name** of the pool you want to use.
 
 ---
 
@@ -85,8 +89,8 @@ Allocate an address from the chosen pool:
 
 ```bash
 osac create publicip \
-  --name <publicip_name> \
-  --pool <pool-id>
+  --name <publicip-name> \
+  --pool <pool-name>
 ```
 
 The PublicIP starts in `PENDING` state while the system reserves an address.
@@ -113,9 +117,9 @@ ComputeInstance:
 
 ```bash
 osac create publicipattachment \
-  --name <attachment_name> \
-  --public-ip <publicip-id> \
-  --compute-instance <computeinstance-id>
+  --name <attachment-name> \
+  --public-ip <publicip-name> \
+  --compute-instance <computeinstance-name>
 ```
 
 The attachment starts in `PENDING` state while the system configures network
@@ -162,7 +166,7 @@ Delete the PublicIPAttachment to stop routing traffic to the ComputeInstance
 while keeping the IP address allocated:
 
 ```bash
-osac delete publicipattachment <attachment-id>
+osac delete publicipattachment <attachment-name>
 ```
 
 The PublicIP remains in `ALLOCATED` state with `ATTACHED: false`. You can
@@ -174,13 +178,13 @@ First detach the IP if it is currently attached (a PublicIP cannot be deleted
 while attached):
 
 ```bash
-osac delete publicipattachment <attachment-id>
+osac delete publicipattachment <attachment-name>
 ```
 
 Then delete the PublicIP to return the address to the pool:
 
 ```bash
-osac delete publicip <publicip-id>
+osac delete publicip <publicip-name>
 ```
 
 The address becomes available for other tenants to allocate.


### PR DESCRIPTION
## Summary

OSAC-828: Adds two documents covering PublicIP networking for OSAC:

1. **Developer guide** (`guides/developer/publicip-guide.md`): step-by-step walkthrough for pool discovery, IP allocation, attachment to a ComputeInstance, connectivity verification, and detach/release. Clearly separates Cloud Provider Admin actions (pool creation) from Tenant User actions (IP allocation, attachment).

2. **Architecture doc** (`architecture/publicip-networking.md`): explains why PublicIPs are needed (VMs isolated on overlay network), the three-resource model (PublicIPPool, PublicIP, PublicIPAttachment), lifecycle phases, traffic flow via MetalLB L2, the service swap pattern, and the full system architecture.

## Why

There was no developer-facing documentation for PublicIP resources. The existing computeinstance guide covers VirtualNetwork and Subnet setup but stops before PublicIP. Tenants and cloud providers need clear guidance on who creates what, how to allocate and attach IPs, and how the underlying networking works.

## Testing

Documentation-only change. Verified markdown renders correctly and cross-links between the two documents are consistent.

## Ticket

- [OSAC-828](https://redhat.atlassian.net/browse/OSAC-828)
- [OSAC-691](https://redhat.atlassian.net/browse/OSAC-691)

<br>

<small>Signed-off-by: akshaynadkarni <25892229+akshaynadkarni@users.noreply.github.com></small>
<small>Assisted-by: Cursor/Claude</small>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive architecture documentation describing PublicIP networking for virtual machine traffic management
  * Added developer guide covering PublicIP allocation, attachment, and complete lifecycle workflows
  * Updated architecture and features documentation indexes with new PublicIP and networking references
<!-- end of auto-generated comment: release notes by coderabbit.ai -->