### PR TITLE
NO-ISSUE: complete compute instance documentation

### DIFF
--- a/guides/developer/computeinstance-catalogitem-guide.md
+++ b/guides/developer/computeinstance-catalogitem-guide.md
@@ -1,0 +1,489 @@
+# Managing Compute Instance Catalog Items
+
+This guide covers catalog items for compute instances: what they are, how
+admins create and manage them, and how users create VMs from them. It explains
+the relationship between a catalog item's `field_definitions` and the
+arguments accepted when creating a ComputeInstance.
+
+## Contents
+
+- [Overview](#overview)
+- [Who does what](#who-does-what)
+- [Prerequisites](#prerequisites)
+- [Browsing catalog items](#browsing-catalog-items)
+  - [List catalog items](#list-catalog-items)
+  - [Inspect a catalog item](#inspect-a-catalog-item)
+- [Admin operations](#admin-operations)
+  - [Create a catalog item](#create-a-catalog-item)
+  - [Publish a catalog item](#publish-a-catalog-item)
+  - [Update a catalog item](#update-a-catalog-item)
+  - [Unpublish a catalog item](#unpublish-a-catalog-item)
+  - [Delete a catalog item](#delete-a-catalog-item)
+- [How field definitions shape VM creation](#how-field-definitions-shape-vm-creation)
+  - [Available paths](#available-paths)
+  - [Editable vs non-editable fields](#editable-vs-non-editable-fields)
+  - [Defaults and validation](#defaults-and-validation)
+  - [Instance type](#instance-type)
+  - [Server-side processing](#server-side-processing)
+- [User operations](#user-operations)
+  - [Create a VM from a catalog item](#create-a-vm-from-a-catalog-item)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## Overview
+
+OSAC uses a three-level hierarchy to provision compute instances:
+
+```text
+Template (admin-only)
+    ↓  referenced by
+Catalog Item (admin-managed, published to users)
+    ↓  used by
+ComputeInstance (user-created VM)
+```
+
+**Templates** are infrastructure blueprints managed through the admin API.
+They define the underlying provisioning logic. Templates are not visible to
+end users.
+
+**Catalog items** reference a template and add a curation layer. Using
+`field_definitions`, the admin controls which ComputeInstance spec fields
+users can set, locks fields to fixed values, provides defaults, and
+optionally validates user input with JSON Schema. Once published
+(`published: true`), catalog items become visible through the public API.
+
+**ComputeInstances** are the VMs that users create. When a user creates a VM
+with `--catalog-item`, the server resolves the underlying template from the
+catalog item and enforces the catalog item's `field_definitions` against the
+user's request.
+
+| Resource | Purpose | Managed by |
+|----------|---------|------------|
+| **ComputeInstanceTemplate** | Infrastructure blueprint for VM provisioning | Cloud Provider Admin |
+| **ComputeInstanceCatalogItem** | Curated offering with field restrictions and defaults | Cloud Provider Admin |
+| **ComputeInstance** | The running VM | Organization User |
+
+---
+
+## Who does what
+
+| Persona | Actions |
+|---------|---------|
+| **Cloud Provider Admin** | Creates templates and catalog items. Publishes, updates, unpublishes, and deletes catalog items. Defines which fields users can control via `field_definitions`. |
+| **Organization User** | Lists published catalog items. Creates VMs using `--catalog-item`. Provides values for editable fields and accepts defaults for the rest. |
+
+Organization Users cannot create, modify, or delete catalog items.
+
+---
+
+## Prerequisites
+
+- The `osac` CLI is installed and configured (API endpoint, authentication
+  token).
+- For admin operations: access to the private admin API.
+- For user operations: a Tenant in `Ready` state (see
+  [Tenant Setup Guide](tenant-setup.md)).
+
+---
+
+## Browsing catalog items
+
+The following operations are available to both Cloud Provider Admins and
+Organization Users.
+
+### List catalog items
+
+List all published catalog items:
+
+```bash
+osac get computeinstancecatalogitems
+```
+
+The output shows each catalog item in a table:
+
+| ID | NAME | TITLE | PUBLISHED |
+|----|------|-------|-----------|
+
+> **Note:** The public API only returns published catalog items. Admins using
+> the private API see all catalog items regardless of publish state.
+
+### Inspect a catalog item
+
+View the full details of a catalog item, including its `field_definitions`:
+
+```bash
+osac get computeinstancecatalogitems <name-or-id> -o yaml
+```
+
+The output shows the catalog item's metadata, title, description, template
+reference, publish state, and the complete list of field definitions with
+their paths, editability, defaults, and validation schemas.
+
+---
+
+## Admin operations
+
+### Create a catalog item
+
+Catalog items are created using `osac create -f` with a YAML file. The
+`field_definitions` structure is too complex for CLI flags, so a file is
+required.
+
+First, find the available compute instance templates:
+
+```bash
+osac get computeinstancetemplates
+```
+
+Create a YAML file (e.g., `standard-vm-catalog-item.yaml`):
+
+```yaml
+'@type': type.googleapis.com/osac.public.v1.ComputeInstanceCatalogItem
+metadata:
+  name: standard-linux-vm
+title: Standard Linux VM
+description: |
+  General-purpose Linux virtual machine with sensible defaults.
+  Users can choose their SSH key, instance type, and boot disk size.
+template: "osac.templates.ocp_virt_vm"
+published: false
+field_definitions:
+  - path: ssh_key
+    display_name: SSH Public Key
+    editable: true
+  - path: instance_type
+    display_name: Instance Type
+    editable: true
+    default: "standard-4-16"
+  - path: image.source_type
+    display_name: Image Source Type
+    editable: false
+    default: "registry"
+  - path: image.source_ref
+    display_name: Image
+    editable: true
+    default: "quay.io/containerdisks/fedora:latest"
+  - path: boot_disk.size_gib
+    display_name: Boot Disk Size (GiB)
+    editable: true
+    default: 20
+    validation_schema: '{"type":"number","minimum":10,"maximum":500}'
+  - path: run_strategy
+    display_name: Run Strategy
+    editable: false
+    default: "Always"
+  - path: user_data
+    display_name: Cloud-init User Data
+    editable: true
+```
+
+Create the catalog item:
+
+```bash
+osac create -f standard-vm-catalog-item.yaml
+```
+
+The catalog item is created with `published: false`. It is not visible to
+users until you publish it.
+
+> **Note:** The YAML file can contain multiple documents separated by `---`,
+> allowing you to create several catalog items in one command.
+
+---
+
+### Publish a catalog item
+
+Publishing makes the catalog item visible to users in the public API. Edit
+the catalog item and set `published: true`:
+
+```bash
+osac edit computeinstancecatalogitems standard-linux-vm
+```
+
+In the editor, change `published` from `false` to `true`, then save and
+exit.
+
+---
+
+### Update a catalog item
+
+To modify a catalog item's title, description, field definitions, or
+template:
+
+```bash
+osac edit computeinstancecatalogitems standard-linux-vm
+```
+
+This opens the catalog item in `$EDITOR`. Make your changes, save, and exit.
+
+Changes to `field_definitions` take effect for new VM requests immediately.
+Existing VMs are not affected — the catalog item reference on a
+ComputeInstance is immutable after creation.
+
+---
+
+### Unpublish a catalog item
+
+To hide a catalog item from users without deleting it, edit it and set
+`published: false`:
+
+```bash
+osac edit computeinstancecatalogitems standard-linux-vm
+```
+
+Unpublished catalog items are no longer returned by the public API and cannot
+be used for new VM creation. Existing VMs that reference the catalog item
+continue to work normally.
+
+> **Note:** Existing VMs that reference an unpublished catalog item continue
+> to run normally. Users can view the catalog item details on their existing
+> ComputeInstance resources, but the catalog item itself is no longer returned
+> by the public List or Get endpoints.
+
+---
+
+### Delete a catalog item
+
+```bash
+osac delete computeinstancecatalogitems standard-linux-vm
+```
+
+---
+
+## How field definitions shape VM creation
+
+Each entry in `field_definitions` controls a single field on the
+ComputeInstance spec. Together, they define the contract between the catalog
+item and the user: which fields the user can set, which are locked, what
+defaults apply, and what validation constraints exist.
+
+### Available paths
+
+The following paths can be used in `field_definitions`. These correspond
+to fields in the ComputeInstance spec. Any path not in this list is silently
+ignored.
+
+| Path | CLI flag | Description |
+|------|----------|-------------|
+| `ssh_key` | `--ssh-key` | SSH public key installed on the VM |
+| `instance_type` | `--instance-type` | Named instance type (e.g., `standard-4-16`) |
+| `run_strategy` | `--run-strategy` | VM run strategy (`Always`, `Halted`, etc.) |
+| `user_data` | `--user-data` | Cloud-init or ignition user data |
+| `image.source_type` | (part of `--image`) | Image source type (e.g., `registry`) |
+| `image.source_ref` | `--image` | Image reference (e.g., OCI image URL) |
+| `boot_disk.size_gib` | `--boot-disk-size` | Boot disk size in GiB |
+| `additional_disks` | — | Additional disk configurations |
+| `network_attachments` | `--network-attachment` | Network attachments (subnet + security groups per NIC) |
+
+These paths use dot notation for nested fields. For example,
+`boot_disk.size_gib` refers to the `size_gib` field inside the `boot_disk`
+object in the ComputeInstance spec.
+
+---
+
+### Editable vs non-editable fields
+
+Each field definition has an `editable` flag that controls whether the user
+can provide their own value:
+
+| `editable` | User provides value | Result |
+|------------|---------------------|--------|
+| `false` | Yes (via CLI flag) | User's value is **silently overridden** by the catalog item default |
+| `false` | No | Catalog item default is applied |
+| `true` | Yes | User's value is accepted (validated against `validation_schema` if present) |
+| `true` | No | Catalog item default is applied (error if no default is defined) |
+
+Non-editable fields enforce consistency. For example, locking `run_strategy`
+to `Always` ensures all VMs from this catalog item are always running,
+regardless of what the user passes on the CLI.
+
+Editable fields give users flexibility. For example, making `ssh_key`
+editable lets each user provide their own public key.
+
+---
+
+### Defaults and validation
+
+**Defaults**: Every non-editable field must have a `default`. Editable fields
+should also have a `default` unless the field is required and must always be
+provided by the user (like `ssh_key`). If an editable field has no default
+and the user does not provide a value, the request fails.
+
+**Validation**: Editable fields can include a `validation_schema` — a JSON
+Schema (draft 2020-12) string. The server validates the user's value against
+this schema. Non-editable fields do not need validation since their value
+always comes from the default.
+
+Example — constrain boot disk size to between 10 and 500 GiB:
+
+```yaml
+- path: boot_disk.size_gib
+  display_name: Boot Disk Size (GiB)
+  editable: true
+  default: 20
+  validation_schema: '{"type":"number","minimum":10,"maximum":500}'
+```
+
+Example — restrict image references to a specific registry:
+
+```yaml
+- path: image.source_ref
+  display_name: Image
+  editable: true
+  default: "quay.io/containerdisks/fedora:latest"
+  validation_schema: '{"type":"string","pattern":"^quay\\.io/containerdisks/"}'
+```
+
+---
+
+### Instance type
+
+Catalog items use the `instance_type` path to control which compute
+configuration users select. Instance types are named bundles of cores and
+memory managed by the admin (see
+[Managing Instance Types](instancetype-guide.md)).
+
+If the catalog item defines `instance_type` with a default value, the server
+validates that the referenced instance type exists and is not OBSOLETE. If
+it is DEPRECATED, the server returns a warning.
+
+---
+
+### Server-side processing
+
+When a user creates a ComputeInstance with `--catalog-item`, the server
+processes the request in this order:
+
+1. **Lookup**: Finds the catalog item by name or ID.
+2. **Access check**: Verifies the catalog item is published and not deleted.
+3. **Template resolution**: Sets the ComputeInstance's `template` to the
+   template referenced by the catalog item.
+4. **Apply field definitions**: For each field definition:
+   - **Non-editable**: overrides any user-provided value with the default.
+   - **Editable with user value**: validates against `validation_schema` if
+     present.
+   - **Editable without user value**: applies the default.
+5. **Validate**: Validates the resulting spec (instance type state, network
+   attachments, etc.) and creates the resource.
+
+Fields not covered by any field definition pass through unchanged — the user
+can set them freely via CLI flags.
+
+---
+
+## User operations
+
+### Create a VM from a catalog item
+
+List the available catalog items to find one that fits your workload:
+
+```bash
+osac get computeinstancecatalogitems
+```
+
+Inspect the catalog item to see which fields you can customize:
+
+```bash
+osac get computeinstancecatalogitems <name-or-id> -o yaml
+```
+
+In the output, review the `field_definitions`:
+- Fields with `editable: true` can be set via CLI flags.
+- Fields with `editable: false` are locked to the catalog item's default —
+  you cannot override them.
+- Fields with a `validation_schema` must match the specified constraints.
+
+Create a VM, providing values for the editable fields:
+
+```bash
+osac create computeinstance \
+  --name my-vm \
+  --catalog-item standard-linux-vm \
+  --instance-type standard-4-16 \
+  --ssh-key "$(cat ~/.ssh/id_ed25519.pub)" \
+  --boot-disk-size 40 \
+  --network-attachment subnet=<subnet-id> \
+  --user-data '#cloud-config
+user: myuser
+password: <password>
+chpasswd:
+  expire: false'
+```
+
+The server applies the catalog item's field definitions to your request.
+Non-editable fields use the catalog item's defaults regardless of what you
+pass. Editable fields accept your values, falling back to catalog item
+defaults for anything you omit.
+
+For the full VM creation walkthrough, see the
+[ComputeInstance Guide](computeinstance-guide.md).
+
+---
+
+## Troubleshooting
+
+### Catalog item not found
+
+```text
+Error: catalog item 'my-catalog-item' is not published (404 Not Found)
+```
+
+The catalog item either does not exist or is not published. Ask your platform
+administrator to verify the catalog item exists and has `published: true`.
+
+### CLI flag ignored for a non-editable field
+
+If you pass a CLI flag for a field that the catalog item marks as
+non-editable, the server silently overrides your value with the catalog
+item's default. There is no error or warning — inspect the catalog item's
+field definitions to see which fields are locked:
+
+```bash
+osac get computeinstancecatalogitems <name-or-id> -o yaml
+```
+
+### Validation failed for a field
+
+```text
+Error: validation failed for field 'boot_disk.size_gib': ...
+```
+
+The value you provided does not match the catalog item's `validation_schema`
+for that field. Inspect the catalog item to see the constraints:
+
+```bash
+osac get computeinstancecatalogitems <name-or-id> -o yaml
+```
+
+Look at the `validation_schema` for the field mentioned in the error to
+understand the allowed values.
+
+### Required field missing
+
+```text
+Error: field 'ssh_key' is required but no value was provided and no default is defined
+```
+
+The catalog item has an editable field with no default, and you did not
+provide a value. Add the corresponding CLI flag to your request (in this
+example, `--ssh-key`).
+
+### Instance type is obsolete
+
+```text
+Error: instance type 'standard-4-16' in field_definitions is obsolete and cannot be used
+```
+
+The catalog item's default instance type has been obsoleted. Update the
+catalog item to reference an ACTIVE instance type:
+
+```bash
+osac edit computeinstancecatalogitems <name-or-id>
+```
+
+List the available instance types to find a replacement:
+
+```bash
+osac get instancetype
+```

--- a/guides/developer/computeinstance-guide.md
+++ b/guides/developer/computeinstance-guide.md
@@ -1,19 +1,17 @@
 # Creating a VM with OSAC
 
-This guide walks through creating a ComputeInstance (virtual machine) using the OSAC CLI,
-including the prerequisite networking resources. It assumes you already have a Tenant in
-`Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
+This guide walks through creating a ComputeInstance (virtual machine) using the OSAC CLI.
+It assumes you already have a Tenant in `Ready` state (see [Tenant Setup Guide](tenant-setup.md))
+and networking resources set up (see [Networking Guide](networking-guide.md)).
 
 ## Contents
 
 - [Prerequisites](#prerequisites)
-- [Step 1: Identify the NetworkClass](#step-1-identify-the-networkclass)
-- [Step 2: Create a VirtualNetwork](#step-2-create-a-virtualnetwork)
-- [Step 3: Create a Subnet](#step-3-create-a-subnet)
-- [Step 4: Choose an instance type](#step-4-choose-an-instance-type)
-- [Step 5: Create the ComputeInstance](#step-5-create-the-computeinstance)
-- [Step 6: Monitor the instance](#step-6-monitor-the-instance)
-- [Step 7: Access the console](#step-7-access-the-console)
+- [Step 1: Find a Compute Instance Catalog Item](#step-1-find-a-compute-instance-catalog-item)
+- [Step 2: Choose an instance type](#step-2-choose-an-instance-type)
+- [Step 3: Create the ComputeInstance](#step-3-create-the-computeinstance)
+- [Step 4: Monitor the instance](#step-4-monitor-the-instance)
+- [Step 5: Access the console](#step-5-access-the-console)
 
 ---
 
@@ -21,68 +19,40 @@ including the prerequisite networking resources. It assumes you already have a T
 
 - The `osac` CLI is installed and configured (API endpoint, authentication token).
 - A Tenant is in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
-- At least one instance type is available (see [Managing Instance Types](instancetype-guide.md)).
-- `oc` CLI configured and logged in to the management cluster (for `oc get vm` monitoring).
+- Networking resources (VirtualNetwork, Subnet, and optionally SecurityGroups) are created
+  and in `READY` state (see [Networking Guide](networking-guide.md)).
+- At least one compute instance catalog item is published and available
+  (see [Compute Instance Catalog Items Guide](computeinstance-catalogitem-guide.md)).
+- At least one instance type is in `ACTIVE` state
+  (see [Managing Instance Types](instancetype-guide.md)).
 
 ---
 
-## Step 1: Identify the NetworkClass
+## Step 1: Find a Compute Instance Catalog Item
 
-List the available network classes to find the one you will use for your VirtualNetwork:
+Catalog items are curated infrastructure offerings that define defaults and constraints for
+compute instances. List the available catalog items:
 
 ```bash
-osac get networkclass
+osac get computeinstancecatalogitems
 ```
 
-Note the `ID` of the NetworkClass you want to use — you will need it in the next step.
+To inspect a catalog item's details (defaults, editable fields):
+
+```bash
+osac get computeinstancecatalogitems <id> -o yaml
+```
+
+Note the **NAME** or **ID** of the catalog item you want to use.
+
+> **Note:** Catalog items are created by platform admins. If no catalog items are available,
+> contact your platform administrator. For details on catalog item lifecycle management and
+> how field definitions control VM creation, see the
+> [Compute Instance Catalog Items Guide](computeinstance-catalogitem-guide.md).
 
 ---
 
-## Step 2: Create a VirtualNetwork
-
-Create a VirtualNetwork associated with the NetworkClass. The `--ipv4-cidr` defines the
-overall IP address range for the network:
-
-```bash
-osac create virtualnetwork \
-  --name <virtualnetwork_name> \
-  --network-class <networkclass-id> \
-  --ipv4-cidr 192.168.0.0/16
-```
-
-Note the VirtualNetwork `ID` from the output — you will need it when creating a Subnet.
-
-Wait for the VirtualNetwork to reach `READY` state:
-
-```bash
-osac get virtualnetwork
-```
-
----
-
-## Step 3: Create a Subnet
-
-Create a Subnet under the VirtualNetwork. The Subnet CIDR must fall within the
-VirtualNetwork's CIDR range (e.g., `192.168.1.0/24` is within `192.168.0.0/16`):
-
-```bash
-osac create subnet \
-  --name <subnet_name> \
-  --virtual-network <virtualnetwork-id> \
-  --ipv4-cidr 192.168.1.0/24
-```
-
-Note the Subnet `ID` from the output — you will need it in the ComputeInstance spec.
-
-Wait for the Subnet to reach `READY` state:
-
-```bash
-osac get subnet
-```
-
----
-
-## Step 4: Choose an instance type
+## Step 2: Choose an instance type
 
 List the available instance types to find the compute configuration for your VM:
 
@@ -95,49 +65,91 @@ Choose an ACTIVE instance type that meets your workload requirements.
 
 Note the **NAME** of the instance type you want to use.
 
+> **Note:** This step is optional if the catalog item already defines a default value for
+> `instance_type`. You can check the catalog item's `field_definitions` to see
+> whether this field has a non-editable default.
+
 For details on instance type lifecycle and management, see
 [Managing Instance Types](instancetype-guide.md).
 
 ---
 
-## Step 5: Create the ComputeInstance
+## Step 3: Create the ComputeInstance
 
-Create a YAML file (e.g., `my-vm.yaml`) with the following content. Replace the `subnet`
-value with the Subnet ID from Step 3 and the `instance_type` with the name from Step 4:
+Create the ComputeInstance using the `osac create computeinstance` command. Use
+`--catalog-item` to reference the catalog item and `--network-attachment` for networking.
+
+The catalog item's `field_definitions` determine which fields you can set. Fields marked
+as `editable: true` accept your values via CLI flags; fields marked as `editable: false`
+are locked to the catalog item's defaults and cannot be overridden. Inspect the catalog
+item's field definitions beforehand to see which flags apply (see
+[How field definitions shape VM creation](computeinstance-catalogitem-guide.md#how-field-definitions-shape-vm-creation)).
+
+```bash
+osac create computeinstance \
+  --name <computeinstance_name> \
+  --catalog-item <catalog-item-name-or-id> \
+  --instance-type <instance-type-name> \
+  --image quay.io/containerdisks/fedora:latest \
+  --ssh-key "$(cat ~/.ssh/id_ed25519.pub)" \
+  --boot-disk-size 10 \
+  --network-attachment subnet=<subnet-id> \
+  --run-strategy Always \
+  --user-data '#cloud-config
+user: <username>
+password: <password>
+chpasswd:
+  expire: false'
+```
+
+> **Note:** The `--ssh-key` flag installs your SSH public key on the VM, enabling SSH access
+> once the instance is running. The `--user-data` field uses cloud-init format. The example
+> above creates a user and disables password expiry, allowing you to log in via the VM
+> console. Adjust the username and password as needed.
+>
+> The `--network-attachment` flag uses the format
+> `subnet=<subnet-id>[,security-groups=<sg-id1>,<sg-id2>]`. Security groups are optional.
+> The flag can be repeated for multiple NICs. See the
+> [Networking Guide](networking-guide.md) for details on creating subnets and security
+> groups.
+
+### Alternative: Create from a YAML file
+
+You can also create a ComputeInstance from a YAML file with `osac create -f`. Create a file
+(e.g., `my-vm.yaml`) with the following content:
 
 ```yaml
 '@type': type.googleapis.com/osac.public.v1.ComputeInstance
 metadata:
-  creators:
-    - <tenant_name>
   name: <computeinstance_name>
-  tenants:
-    - <tenant_name>
 spec:
-  boot_disk:
-    size_gib: 10
+  catalog_item: <catalog-item-name-or-id>
   instance_type: <instance-type-name>
   image:
     source_ref: quay.io/containerdisks/fedora:latest
     source_type: registry
-  subnet: <subnet-id>
+  ssh_key: <ssh-public-key>
+  boot_disk:
+    size_gib: 10
+  network_attachments:
+    - subnet: <subnet-id>
+  run_strategy: Always
   user_data: |
     #cloud-config
     user: <username>
     password: <password>
     chpasswd:
       expire: false
-  run_strategy: Always
-  template: osac.templates.ocp_virt_vm
-  template_parameters:
-    exposed_ports:
-      '@type': type.googleapis.com/google.protobuf.StringValue
-      value: 22/tcp
 ```
 
-> **Note:** The `user_data` field uses cloud-init format. The example above creates a user
-> and disables password expiry, allowing you to log in via the VM console. Adjust the
-> username and password as needed.
+To attach security groups in the YAML, add them to the network attachment:
+
+```yaml
+  network_attachments:
+    - subnet: <subnet-id>
+      security_groups:
+        - <securitygroup-id>
+```
 
 Create the instance:
 
@@ -147,7 +159,7 @@ osac create -f my-vm.yaml
 
 ---
 
-## Step 6: Monitor the instance
+## Step 4: Monitor the instance
 
 Track the ComputeInstance status through the OSAC CLI:
 
@@ -155,24 +167,24 @@ Track the ComputeInstance status through the OSAC CLI:
 osac get computeinstance
 ```
 
-You can also monitor the underlying VM on the Kubernetes cluster:
-
-```bash
-oc get vm -A
-```
-
 Wait for the ComputeInstance state to reach `RUNNING`.
 
 ---
 
-## Step 7: Access the console
+## Step 5: Access the console
 
-Once the ComputeInstance is running, attach to its console:
+Once the ComputeInstance is running, attach to its serial console:
 
 ```bash
-osac console computeinstance <computeinstance-id>
+osac console serial computeinstance <computeinstance-name-or-id>
 ```
 
-Log in with the credentials defined in `user_data`
+Log in with the credentials defined in `user_data`.
 
 > **Tip:** To exit the console, press `Ctrl+]`.
+
+To connect via VNC instead:
+
+```bash
+osac console vnc computeinstance <computeinstance-name-or-id>
+```

--- a/guides/developer/networking-guide.md
+++ b/guides/developer/networking-guide.md
@@ -1,0 +1,202 @@
+# Setting Up Networking with OSAC
+
+This guide walks through creating the networking resources required before provisioning
+compute instances: VirtualNetworks and Subnets. It also covers SecurityGroups, which are
+optional and only needed when you want to apply firewall rules. It assumes you already
+have a Tenant in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
+
+## Contents
+
+- [Prerequisites](#prerequisites)
+- [Overview](#overview)
+- [Step 1: Identify the NetworkClass](#step-1-identify-the-networkclass)
+- [Step 2: Create a VirtualNetwork](#step-2-create-a-virtualnetwork)
+- [Step 3: Create a Subnet](#step-3-create-a-subnet)
+- [Step 4: Create a SecurityGroup (optional)](#step-4-create-a-securitygroup-optional)
+- [Next steps](#next-steps)
+
+---
+
+## Prerequisites
+
+- The `osac` CLI is installed and configured (API endpoint, authentication token).
+- A Tenant is in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
+
+---
+
+## Overview
+
+OSAC networking follows a hierarchical model:
+
+```text
+NetworkClass (platform-defined, read-only)
+└── VirtualNetwork (tenant L2 network with CIDR)
+      ├── Subnet (CIDR range within VirtualNetwork)
+      └── SecurityGroup (optional — firewall rules scoped to VirtualNetwork)
+```
+
+- A **NetworkClass** is a platform-level resource that defines the type of network
+  infrastructure available. It is read-only for tenants.
+- A **VirtualNetwork** is a tenant-scoped L2 network associated with a NetworkClass.
+  It defines an overall IPv4 CIDR range.
+- A **Subnet** is a CIDR range within a VirtualNetwork. Compute instances attach to
+  subnets via network attachments.
+- A **SecurityGroup** defines ingress and egress firewall rules scoped to a
+  VirtualNetwork. Security groups follow a **default-deny** policy — traffic is blocked
+  unless a rule explicitly allows it. Rules are stateful, so return traffic for
+  established connections is automatically allowed.
+
+---
+
+## Step 1: Identify the NetworkClass
+
+List the available network classes to find the one you will use for your VirtualNetwork:
+
+```bash
+osac get networkclass
+```
+
+Note the `ID` of the NetworkClass you want to use — you will need it in the next step.
+
+---
+
+## Step 2: Create a VirtualNetwork
+
+Create a VirtualNetwork associated with the NetworkClass. The `--ipv4-cidr` defines the
+overall IP address range for the network:
+
+```bash
+osac create virtualnetwork \
+  --name <virtualnetwork_name> \
+  --network-class <networkclass-id> \
+  --ipv4-cidr 192.168.0.0/16
+```
+
+Note the VirtualNetwork `ID` from the output — you will need it when creating Subnets
+and SecurityGroups.
+
+Wait for the VirtualNetwork to reach `READY` state:
+
+```bash
+osac get virtualnetwork
+```
+
+---
+
+## Step 3: Create a Subnet
+
+Create a Subnet under the VirtualNetwork. The Subnet CIDR must fall within the
+VirtualNetwork's CIDR range (e.g., `192.168.1.0/24` is within `192.168.0.0/16`):
+
+```bash
+osac create subnet \
+  --name <subnet_name> \
+  --virtual-network <virtualnetwork-id> \
+  --ipv4-cidr 192.168.1.0/24
+```
+
+Note the Subnet `ID` from the output — you will need it when creating compute instances.
+
+Wait for the Subnet to reach `READY` state:
+
+```bash
+osac get subnet
+```
+
+---
+
+## Step 4: Create a SecurityGroup (optional)
+
+SecurityGroups are optional. Create one only when you need firewall rules to control
+traffic to and from compute instances. They are scoped to a VirtualNetwork and follow a
+**default-deny** policy: all traffic is blocked unless explicitly allowed by a rule.
+
+### Create a security group with rules
+
+Use `--ingress` and `--egress` flags to define rules. Each rule is a comma-separated
+list of `key=value` pairs:
+
+```bash
+osac create securitygroup \
+  --name <securitygroup_name> \
+  --virtual-network <virtualnetwork-id> \
+  --ingress protocol=tcp,port-from=22,port-to=22,ipv4-cidr=0.0.0.0/0 \
+  --ingress protocol=tcp,port-from=80,port-to=80,ipv4-cidr=0.0.0.0/0 \
+  --ingress protocol=tcp,port-from=443,port-to=443,ipv4-cidr=0.0.0.0/0 \
+  --egress protocol=all,ipv4-cidr=0.0.0.0/0
+```
+
+The example above allows inbound SSH (port 22), HTTP (port 80), and HTTPS (port 443)
+from any IPv4 address, and permits all outbound traffic.
+
+Note the SecurityGroup `ID` from the output — you will need it when creating compute
+instances.
+
+Wait for the SecurityGroup to reach `READY` state:
+
+```bash
+osac get securitygroup
+```
+
+### Rule format
+
+Each `--ingress` or `--egress` flag takes a rule in `key=value,...` format with the
+following keys:
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `protocol` | Yes | One of: `tcp`, `udp`, `icmp`, `all` |
+| `port-from` | For `tcp`/`udp` | Start of port range (1–65535) |
+| `port-to` | For `tcp`/`udp` | End of port range (1–65535), must be >= `port-from` |
+| `ipv4-cidr` | No | IPv4 CIDR block (e.g., `0.0.0.0/0` for all, `10.0.0.0/8` for private) |
+| `ipv6-cidr` | No | IPv6 CIDR block (e.g., `::/0` for all) |
+
+- For `icmp` and `all` protocols, port fields are ignored.
+- Both `ipv4-cidr` and `ipv6-cidr` can be set on a single rule to create a dual-stack
+  rule.
+- The `--ingress` and `--egress` flags can each be repeated to add multiple rules.
+
+### Examples
+
+Allow only SSH from a specific network:
+
+```bash
+osac create securitygroup \
+  --name ssh-only \
+  --virtual-network <virtualnetwork-id> \
+  --ingress protocol=tcp,port-from=22,port-to=22,ipv4-cidr=10.0.0.0/8
+```
+
+Allow all traffic (open security group):
+
+```bash
+osac create securitygroup \
+  --name allow-all \
+  --virtual-network <virtualnetwork-id> \
+  --ingress protocol=all,ipv4-cidr=0.0.0.0/0 \
+  --egress protocol=all,ipv4-cidr=0.0.0.0/0
+```
+
+Allow a range of UDP ports:
+
+```bash
+osac create securitygroup \
+  --name udp-range \
+  --virtual-network <virtualnetwork-id> \
+  --ingress protocol=udp,port-from=5000,port-to=5100,ipv4-cidr=0.0.0.0/0
+```
+
+### Inspect a security group
+
+```bash
+osac describe securitygroup <securitygroup-name-or-id>
+```
+
+This displays the security group's state and a table of all ingress and egress rules.
+
+---
+
+## Next steps
+
+With networking in place, you can create compute instances that attach to your Subnets
+(and optionally SecurityGroups). See [Creating a VM with OSAC](computeinstance-guide.md).


### PR DESCRIPTION
Add networking guide covering VirtualNetwork, Subnet, and SecurityGroup creation. Add catalog item guide covering lifecycle management and how field_definitions control VM creation arguments. Update the compute instance guide with prerequisites linking to both new guides, remove oc CLI references, and explain editable field constraints.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new networking guide covering setup of virtual networks, subnets, and security groups, plus common firewall rule patterns.
  * Added a new compute instance catalog item guide with end-to-end instructions for listing, configuring, publishing, and troubleshooting catalog items.
  * Updated the compute instance guide to reflect the new workflow for creating VMs from catalog items, including networking setup, YAML examples, monitoring, and console access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->