### PR TITLE
NO-ISSUE: add gRPC and REST API examples to developer guides

### DIFF
--- a/guides/developer/computeinstance-catalogitem-guide.md
+++ b/guides/developer/computeinstance-catalogitem-guide.md
@@ -5,6 +5,10 @@ admins create and manage them, and how users create VMs from them. It explains
 the relationship between a catalog item's `field_definitions` and the
 arguments accepted when creating a ComputeInstance.
 
+Each step shows the `osac` CLI command and the equivalent gRPC / REST API
+calls so that the same guide works for both CLI users and application
+developers integrating with OSAC's API.
+
 ## Contents
 
 - [Overview](#overview)
@@ -54,9 +58,9 @@ optionally validates user input with JSON Schema. Once published
 (`published: true`), catalog items become visible through the public API.
 
 **ComputeInstances** are the VMs that users create. When a user creates a VM
-with `--catalog-item`, the server resolves the underlying template from the
-catalog item and enforces the catalog item's `field_definitions` against the
-user's request.
+with `--catalog-item` (CLI) or `catalog_item` (API), the server resolves the
+underlying template from the catalog item and enforces the catalog item's
+`field_definitions` against the user's request.
 
 | Resource | Purpose | Managed by |
 |----------|---------|------------|
@@ -71,7 +75,7 @@ user's request.
 | Persona | Actions |
 |---------|---------|
 | **Cloud Provider Admin** | Creates templates and catalog items. Publishes, updates, unpublishes, and deletes catalog items. Defines which fields users can control via `field_definitions`. |
-| **Organization User** | Lists published catalog items. Creates VMs using `--catalog-item`. Provides values for editable fields and accepts defaults for the rest. |
+| **Organization User** | Lists published catalog items. Creates VMs using `--catalog-item` (CLI) or `catalog_item` (API). Provides values for editable fields and accepts defaults for the rest. |
 
 Organization Users cannot create, modify, or delete catalog items.
 
@@ -79,8 +83,27 @@ Organization Users cannot create, modify, or delete catalog items.
 
 ## Prerequisites
 
+**CLI users:**
+
 - The `osac` CLI is installed and configured (API endpoint, authentication
   token).
+
+**API users:**
+
+- `grpcurl` (for gRPC) or `curl` (for REST) is installed.
+- Set the following environment variables for the examples in this guide:
+
+  ```bash
+  export OSAC_API="<api-endpoint>"    # host:port (e.g., fulfillment-api.osac.svc:443)
+  export TOKEN="<authentication-token>"
+
+  # Skip TLS verification in development environments:
+  # export GRPCURL_FLAGS="-insecure"
+  # export CURL_FLAGS="-k"
+  ```
+
+**Both:**
+
 - For admin operations: access to the private admin API.
 - For user operations: a Tenant in `Ready` state (see
   [Tenant Setup Guide](tenant-setup.md)).
@@ -96,14 +119,33 @@ Organization Users.
 
 List all published catalog items:
 
+**CLI:**
+
 ```bash
 osac get computeinstancecatalogitems
 ```
 
-The output shows each catalog item in a table:
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.ComputeInstanceCatalogItems/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instance_catalog_items"
+```
+
+The CLI renders the output as a table:
 
 | ID | NAME | TITLE | PUBLISHED |
 |----|------|-------|-----------|
+
+The gRPC and REST commands return JSON responses containing the same
+fields.
 
 > **Note:** The public API only returns published catalog items. Admins using
 > the private API see all catalog items regardless of publish state.
@@ -112,8 +154,25 @@ The output shows each catalog item in a table:
 
 View the full details of a catalog item, including its `field_definitions`:
 
+**CLI:**
+
 ```bash
 osac get computeinstancecatalogitems <name-or-id> -o yaml
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<catalog-item-id>"}' \
+  $OSAC_API osac.public.v1.ComputeInstanceCatalogItems/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instance_catalog_items/<catalog-item-id>"
 ```
 
 The output shows the catalog item's metadata, title, description, template
@@ -130,10 +189,31 @@ Catalog items are created using `osac create -f` with a YAML file. The
 `field_definitions` structure is too complex for CLI flags, so a file is
 required.
 
+> **Note:** Catalog item management (create, update, publish, unpublish,
+> delete) uses the **private** admin API (`osac.private.v1`). Template
+> discovery below uses the **public** read-only API since templates are
+> readable by all authenticated users.
+
 First, find the available compute instance templates:
+
+**CLI:**
 
 ```bash
 osac get computeinstancetemplates
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.ComputeInstanceTemplates/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instance_templates"
 ```
 
 Create a YAML file (e.g., `standard-vm-catalog-item.yaml`):
@@ -178,10 +258,59 @@ field_definitions:
     editable: true
 ```
 
-Create the catalog item:
+**CLI:**
 
 ```bash
 osac create -f standard-vm-catalog-item.yaml
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {
+      "name": "standard-linux-vm"
+    },
+    "title": "Standard Linux VM",
+    "description": "General-purpose Linux virtual machine with sensible defaults.\nUsers can choose their SSH key, instance type, and boot disk size.",
+    "template": "osac.templates.ocp_virt_vm",
+    "published": false,
+    "field_definitions": [
+      {"path": "ssh_key", "display_name": "SSH Public Key", "editable": true},
+      {"path": "instance_type", "display_name": "Instance Type", "editable": true, "default": "standard-4-16"},
+      {"path": "image.source_type", "display_name": "Image Source Type", "editable": false, "default": "registry"},
+      {"path": "image.source_ref", "display_name": "Image", "editable": true, "default": "quay.io/containerdisks/fedora:latest"},
+      {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size (GiB)", "editable": true, "default": 20, "validation_schema": "{\"type\":\"number\",\"minimum\":10,\"maximum\":500}"},
+      {"path": "run_strategy", "display_name": "Run Strategy", "editable": false, "default": "Always"},
+      {"path": "user_data", "display_name": "Cloud-init User Data", "editable": true}
+    ]
+  }
+}' $OSAC_API osac.private.v1.ComputeInstanceCatalogItems/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {
+    "name": "standard-linux-vm"
+  },
+  "title": "Standard Linux VM",
+  "description": "General-purpose Linux virtual machine with sensible defaults.\nUsers can choose their SSH key, instance type, and boot disk size.",
+  "template": "osac.templates.ocp_virt_vm",
+  "published": false,
+  "field_definitions": [
+    {"path": "ssh_key", "display_name": "SSH Public Key", "editable": true},
+    {"path": "instance_type", "display_name": "Instance Type", "editable": true, "default": "standard-4-16"},
+    {"path": "image.source_type", "display_name": "Image Source Type", "editable": false, "default": "registry"},
+    {"path": "image.source_ref", "display_name": "Image", "editable": true, "default": "quay.io/containerdisks/fedora:latest"},
+    {"path": "boot_disk.size_gib", "display_name": "Boot Disk Size (GiB)", "editable": true, "default": 20, "validation_schema": "{\"type\":\"number\",\"minimum\":10,\"maximum\":500}"},
+    {"path": "run_strategy", "display_name": "Run Strategy", "editable": false, "default": "Always"},
+    {"path": "user_data", "display_name": "Cloud-init User Data", "editable": true}
+  ]
+}' "https://$OSAC_API/api/private/v1/compute_instance_catalog_items"
 ```
 
 The catalog item is created with `published: false`. It is not visible to
@@ -197,12 +326,37 @@ users until you publish it.
 Publishing makes the catalog item visible to users in the public API. Edit
 the catalog item and set `published: true`:
 
+**CLI:**
+
 ```bash
 osac edit computeinstancecatalogitems standard-linux-vm
 ```
 
 In the editor, change `published` from `false` to `true`, then save and
 exit.
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "id": "<catalog-item-id>",
+    "published": true
+  },
+  "update_mask": {
+    "paths": ["published"]
+  }
+}' $OSAC_API osac.private.v1.ComputeInstanceCatalogItems/Update
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "published": true
+}' "https://$OSAC_API/api/private/v1/compute_instance_catalog_items/<catalog-item-id>?update_mask=published"
+```
 
 ---
 
@@ -211,11 +365,38 @@ exit.
 To modify a catalog item's title, description, field definitions, or
 template:
 
+**CLI:**
+
 ```bash
 osac edit computeinstancecatalogitems standard-linux-vm
 ```
 
 This opens the catalog item in `$EDITOR`. Make your changes, save, and exit.
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "id": "<catalog-item-id>",
+    "title": "Updated Title",
+    "description": "Updated description."
+  },
+  "update_mask": {
+    "paths": ["title", "description"]
+  }
+}' $OSAC_API osac.private.v1.ComputeInstanceCatalogItems/Update
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "title": "Updated Title",
+  "description": "Updated description."
+}' "https://$OSAC_API/api/private/v1/compute_instance_catalog_items/<catalog-item-id>?update_mask=title,description"
+```
 
 Changes to `field_definitions` take effect for new VM requests immediately.
 Existing VMs are not affected — the catalog item reference on a
@@ -228,8 +409,33 @@ ComputeInstance is immutable after creation.
 To hide a catalog item from users without deleting it, edit it and set
 `published: false`:
 
+**CLI:**
+
 ```bash
 osac edit computeinstancecatalogitems standard-linux-vm
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "id": "<catalog-item-id>",
+    "published": false
+  },
+  "update_mask": {
+    "paths": ["published"]
+  }
+}' $OSAC_API osac.private.v1.ComputeInstanceCatalogItems/Update
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "published": false
+}' "https://$OSAC_API/api/private/v1/compute_instance_catalog_items/<catalog-item-id>?update_mask=published"
 ```
 
 Unpublished catalog items are no longer returned by the public API and cannot
@@ -245,8 +451,25 @@ continue to work normally.
 
 ### Delete a catalog item
 
+**CLI:**
+
 ```bash
 osac delete computeinstancecatalogitems standard-linux-vm
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<catalog-item-id>"}' \
+  $OSAC_API osac.private.v1.ComputeInstanceCatalogItems/Delete
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/private/v1/compute_instance_catalog_items/<catalog-item-id>"
 ```
 
 ---
@@ -264,17 +487,17 @@ The following paths can be used in `field_definitions`. These correspond
 to fields in the ComputeInstance spec. Any path not in this list is silently
 ignored.
 
-| Path | CLI flag | Description |
-|------|----------|-------------|
-| `ssh_key` | `--ssh-key` | SSH public key installed on the VM |
-| `instance_type` | `--instance-type` | Named instance type (e.g., `standard-4-16`) |
-| `run_strategy` | `--run-strategy` | VM run strategy (`Always`, `Halted`, etc.) |
-| `user_data` | `--user-data` | Cloud-init or ignition user data |
-| `image.source_type` | (part of `--image`) | Image source type (e.g., `registry`) |
-| `image.source_ref` | `--image` | Image reference (e.g., OCI image URL) |
-| `boot_disk.size_gib` | `--boot-disk-size` | Boot disk size in GiB |
-| `additional_disks` | — | Additional disk configurations |
-| `network_attachments` | `--network-attachment` | Network attachments (subnet + security groups per NIC) |
+| Path | CLI flag | API field | Description |
+|------|----------|-----------|-------------|
+| `ssh_key` | `--ssh-key` | `spec.ssh_key` | SSH public key installed on the VM |
+| `instance_type` | `--instance-type` | `spec.instance_type` | Named instance type (e.g., `standard-4-16`) |
+| `run_strategy` | `--run-strategy` | `spec.run_strategy` | VM run strategy (`Always`, `Halted`, etc.) |
+| `user_data` | `--user-data` | `spec.user_data` | Cloud-init or ignition user data |
+| `image.source_type` | (part of `--image`) | `spec.image.source_type` | Image source type (e.g., `registry`) |
+| `image.source_ref` | `--image` | `spec.image.source_ref` | Image reference (e.g., OCI image URL) |
+| `boot_disk.size_gib` | `--boot-disk-size` | `spec.boot_disk.size_gib` | Boot disk size in GiB |
+| `additional_disks` | — | `spec.additional_disks` | Additional disk configurations |
+| `network_attachments` | `--network-attachment` | `spec.network_attachments` | Network attachments (subnet + security groups per NIC) |
 
 These paths use dot notation for nested fields. For example,
 `boot_disk.size_gib` refers to the `size_gib` field inside the `boot_disk`
@@ -289,14 +512,14 @@ can provide their own value:
 
 | `editable` | User provides value | Result |
 |------------|---------------------|--------|
-| `false` | Yes (via CLI flag) | User's value is **silently overridden** by the catalog item default |
+| `false` | Yes (via CLI flag or API field) | User's value is **silently overridden** by the catalog item default |
 | `false` | No | Catalog item default is applied |
 | `true` | Yes | User's value is accepted (validated against `validation_schema` if present) |
 | `true` | No | Catalog item default is applied (error if no default is defined) |
 
 Non-editable fields enforce consistency. For example, locking `run_strategy`
 to `Always` ensures all VMs from this catalog item are always running,
-regardless of what the user passes on the CLI.
+regardless of what the user passes on the CLI or in the API request.
 
 Editable fields give users flexibility. For example, making `ssh_key`
 editable lets each user provide their own public key.
@@ -352,8 +575,8 @@ it is DEPRECATED, the server returns a warning.
 
 ### Server-side processing
 
-When a user creates a ComputeInstance with `--catalog-item`, the server
-processes the request in this order:
+When a user creates a ComputeInstance with `--catalog-item` (CLI) or
+`catalog_item` (API), the server processes the request in this order:
 
 1. **Lookup**: Finds the catalog item by name or ID.
 2. **Access check**: Verifies the catalog item is published and not deleted.
@@ -368,7 +591,7 @@ processes the request in this order:
    attachments, etc.) and creates the resource.
 
 Fields not covered by any field definition pass through unchanged — the user
-can set them freely via CLI flags.
+can set them freely via CLI flags or API fields.
 
 ---
 
@@ -378,23 +601,58 @@ can set them freely via CLI flags.
 
 List the available catalog items to find one that fits your workload:
 
+**CLI:**
+
 ```bash
 osac get computeinstancecatalogitems
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.ComputeInstanceCatalogItems/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instance_catalog_items"
+```
+
 Inspect the catalog item to see which fields you can customize:
+
+**CLI:**
 
 ```bash
 osac get computeinstancecatalogitems <name-or-id> -o yaml
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<catalog-item-id>"}' \
+  $OSAC_API osac.public.v1.ComputeInstanceCatalogItems/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instance_catalog_items/<catalog-item-id>"
+```
+
 In the output, review the `field_definitions`:
-- Fields with `editable: true` can be set via CLI flags.
+- Fields with `editable: true` can be set via CLI flags or API fields.
 - Fields with `editable: false` are locked to the catalog item's default —
   you cannot override them.
 - Fields with a `validation_schema` must match the specified constraints.
 
 Create a VM, providing values for the editable fields:
+
+**CLI:**
 
 ```bash
 osac create computeinstance \
@@ -409,6 +667,45 @@ user: myuser
 password: <password>
 chpasswd:
   expire: false'
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {
+      "name": "my-vm"
+    },
+    "spec": {
+      "catalog_item": "standard-linux-vm",
+      "instance_type": "standard-4-16",
+      "ssh_key": "<ssh-public-key>",
+      "boot_disk": {"size_gib": 40},
+      "network_attachments": [{"subnet": "<subnet-id>"}],
+      "user_data": "#cloud-config\nuser: myuser\npassword: <password>\nchpasswd:\n  expire: false"
+    }
+  }
+}' $OSAC_API osac.public.v1.ComputeInstances/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {
+    "name": "my-vm"
+  },
+  "spec": {
+    "catalog_item": "standard-linux-vm",
+    "instance_type": "standard-4-16",
+    "ssh_key": "<ssh-public-key>",
+    "boot_disk": {"size_gib": 40},
+    "network_attachments": [{"subnet": "<subnet-id>"}],
+    "user_data": "#cloud-config\nuser: myuser\npassword: <password>\nchpasswd:\n  expire: false"
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/compute_instances"
 ```
 
 The server applies the catalog item's field definitions to your request.
@@ -432,9 +729,9 @@ Error: catalog item 'my-catalog-item' is not published (404 Not Found)
 The catalog item either does not exist or is not published. Ask your platform
 administrator to verify the catalog item exists and has `published: true`.
 
-### CLI flag ignored for a non-editable field
+### CLI flag or API field ignored for a non-editable field
 
-If you pass a CLI flag for a field that the catalog item marks as
+If you pass a CLI flag or API field for a field that the catalog item marks as
 non-editable, the server silently overrides your value with the catalog
 item's default. There is no error or warning — inspect the catalog item's
 field definitions to see which fields are locked:
@@ -466,8 +763,8 @@ Error: field 'ssh_key' is required but no value was provided and no default is d
 ```
 
 The catalog item has an editable field with no default, and you did not
-provide a value. Add the corresponding CLI flag to your request (in this
-example, `--ssh-key`).
+provide a value. Add the corresponding CLI flag (e.g., `--ssh-key`) or
+API field (e.g., `spec.ssh_key`) to your request.
 
 ### Instance type is obsolete
 

--- a/guides/developer/computeinstance-guide.md
+++ b/guides/developer/computeinstance-guide.md
@@ -1,6 +1,7 @@
 # Creating a VM with OSAC
 
-This guide walks through creating a ComputeInstance (virtual machine) using the OSAC CLI.
+This guide walks through creating a ComputeInstance (virtual machine) using the OSAC CLI
+or the gRPC / REST API.
 It assumes you already have a Tenant in `Ready` state (see [Tenant Setup Guide](tenant-setup.md))
 and networking resources set up (see [Networking Guide](networking-guide.md)).
 
@@ -17,7 +18,26 @@ and networking resources set up (see [Networking Guide](networking-guide.md)).
 
 ## Prerequisites
 
+**CLI users:**
+
 - The `osac` CLI is installed and configured (API endpoint, authentication token).
+
+**API users:**
+
+- `grpcurl` (for gRPC) or `curl` (for REST) is installed.
+- Set the following environment variables for the examples in this guide:
+
+  ```bash
+  export OSAC_API="<api-endpoint>"    # host:port (e.g., fulfillment-api.osac.svc:443)
+  export TOKEN="<authentication-token>"
+
+  # Skip TLS verification in development environments:
+  # export GRPCURL_FLAGS="-insecure"
+  # export CURL_FLAGS="-k"
+  ```
+
+**Both:**
+
 - A Tenant is in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
 - Networking resources (VirtualNetwork, Subnet, and optionally SecurityGroups) are created
   and in `READY` state (see [Networking Guide](networking-guide.md)).
@@ -33,14 +53,47 @@ and networking resources set up (see [Networking Guide](networking-guide.md)).
 Catalog items are curated infrastructure offerings that define defaults and constraints for
 compute instances. List the available catalog items:
 
+**CLI:**
+
 ```bash
 osac get computeinstancecatalogitems
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.ComputeInstanceCatalogItems/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instance_catalog_items"
+```
+
 To inspect a catalog item's details (defaults, editable fields):
+
+**CLI:**
 
 ```bash
 osac get computeinstancecatalogitems <id> -o yaml
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<id>"}' \
+  $OSAC_API osac.public.v1.ComputeInstanceCatalogItems/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instance_catalog_items/<id>"
 ```
 
 Note the **NAME** or **ID** of the catalog item you want to use.
@@ -56,8 +109,24 @@ Note the **NAME** or **ID** of the catalog item you want to use.
 
 List the available instance types to find the compute configuration for your VM:
 
+**CLI:**
+
 ```bash
 osac get instancetype
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.InstanceTypes/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/instance_types"
 ```
 
 The output shows each type's name, cores, memory, state, and description.
@@ -76,14 +145,16 @@ For details on instance type lifecycle and management, see
 
 ## Step 3: Create the ComputeInstance
 
-Create the ComputeInstance using the `osac create computeinstance` command. Use
-`--catalog-item` to reference the catalog item and `--network-attachment` for networking.
+Create the ComputeInstance using the CLI or API. Use the catalog item and specify
+networking via the subnet (and optionally security groups).
 
 The catalog item's `field_definitions` determine which fields you can set. Fields marked
-as `editable: true` accept your values via CLI flags; fields marked as `editable: false`
+as `editable: true` accept your values; fields marked as `editable: false`
 are locked to the catalog item's defaults and cannot be overridden. Inspect the catalog
-item's field definitions beforehand to see which flags apply (see
+item's field definitions beforehand to see which fields apply (see
 [How field definitions shape VM creation](computeinstance-catalogitem-guide.md#how-field-definitions-shape-vm-creation)).
+
+**CLI:**
 
 ```bash
 osac create computeinstance \
@@ -102,6 +173,63 @@ chpasswd:
   expire: false'
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {
+      "name": "<computeinstance_name>"
+    },
+    "spec": {
+      "catalog_item": "<catalog-item-name-or-id>",
+      "instance_type": "<instance-type-name>",
+      "image": {
+        "source_type": "registry",
+        "source_ref": "quay.io/containerdisks/fedora:latest"
+      },
+      "ssh_key": "<ssh-public-key>",
+      "boot_disk": {
+        "size_gib": 10
+      },
+      "network_attachments": [
+        {"subnet": "<subnet-id>"}
+      ],
+      "run_strategy": "Always",
+      "user_data": "#cloud-config\nuser: <username>\npassword: <password>\nchpasswd:\n  expire: false"
+    }
+  }
+}' $OSAC_API osac.public.v1.ComputeInstances/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {
+    "name": "<computeinstance_name>"
+  },
+  "spec": {
+    "catalog_item": "<catalog-item-name-or-id>",
+    "instance_type": "<instance-type-name>",
+    "image": {
+      "source_type": "registry",
+      "source_ref": "quay.io/containerdisks/fedora:latest"
+    },
+    "ssh_key": "<ssh-public-key>",
+    "boot_disk": {
+      "size_gib": 10
+    },
+    "network_attachments": [
+      {"subnet": "<subnet-id>"}
+    ],
+    "run_strategy": "Always",
+    "user_data": "#cloud-config\nuser: <username>\npassword: <password>\nchpasswd:\n  expire: false"
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/compute_instances"
+```
+
 > **Note:** The `--ssh-key` flag installs your SSH public key on the VM, enabling SSH access
 > once the instance is running. The `--user-data` field uses cloud-init format. The example
 > above creates a user and disables password expiry, allowing you to log in via the VM
@@ -109,9 +237,22 @@ chpasswd:
 >
 > The `--network-attachment` flag uses the format
 > `subnet=<subnet-id>[,security-groups=<sg-id1>,<sg-id2>]`. Security groups are optional.
-> The flag can be repeated for multiple NICs. See the
+> The flag can be repeated for multiple NICs. In the API, use an array of
+> `network_attachments` objects, each with a `subnet` field and an optional
+> `security_groups` array. See the
 > [Networking Guide](networking-guide.md) for details on creating subnets and security
 > groups.
+
+To attach security groups via the API, add them to each network attachment:
+
+```json
+"network_attachments": [
+  {
+    "subnet": "<subnet-id>",
+    "security_groups": ["<securitygroup-id-1>", "<securitygroup-id-2>"]
+  }
+]
+```
 
 ### Alternative: Create from a YAML file
 
@@ -161,13 +302,46 @@ osac create -f my-vm.yaml
 
 ## Step 4: Monitor the instance
 
-Track the ComputeInstance status through the OSAC CLI:
+Track the ComputeInstance status:
+
+**CLI:**
 
 ```bash
 osac get computeinstance
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.ComputeInstances/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instances"
+```
+
 Wait for the ComputeInstance state to reach `RUNNING`.
+
+To get a specific instance by ID:
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<computeinstance-id>"}' \
+  $OSAC_API osac.public.v1.ComputeInstances/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instances/<computeinstance-id>"
+```
 
 ---
 
@@ -188,3 +362,8 @@ To connect via VNC instead:
 ```bash
 osac console vnc computeinstance <computeinstance-name-or-id>
 ```
+
+> **Note:** Console access is only available through the `osac` CLI, which
+> establishes a bidirectional streaming connection via the
+> `osac.public.v1.ConsoleProxy/Connect` gRPC stream. There is no REST
+> equivalent for interactive console sessions.

--- a/guides/developer/instancetype-guide.md
+++ b/guides/developer/instancetype-guide.md
@@ -6,6 +6,10 @@ by name. It covers the full lifecycle: creating an instance type, listing and
 describing available types, deprecating and obsoleting types that are being
 phased out, reactivating types, and deleting types that are no longer needed.
 
+Each step shows the `osac` CLI command and, for API-facing operations, the
+equivalent gRPC / REST API calls so that the same guide works for both CLI
+users and application developers integrating with OSAC's API.
+
 ## Contents
 
 - [Overview](#overview)
@@ -56,8 +60,27 @@ Organization Users cannot create, modify, or delete instance types.
 
 ## Prerequisites
 
+**CLI users:**
+
 - The `osac` CLI is installed and configured (API endpoint, authentication
   token).
+
+**API users:**
+
+- `grpcurl` (for gRPC) or `curl` (for REST) is installed.
+- Set the following environment variables for the examples in this guide:
+
+  ```bash
+  export OSAC_API="<api-endpoint>"    # host:port (e.g., fulfillment-api.osac.svc:443)
+  export TOKEN="<authentication-token>"
+
+  # Skip TLS verification in development environments:
+  # export GRPCURL_FLAGS="-insecure"
+  # export CURL_FLAGS="-k"
+  ```
+
+**Both:**
+
 - For admin operations: access to the private admin API.
 - For user operations: a Tenant in `Ready` state (see
   [Tenant Setup Guide](tenant-setup.md)).
@@ -73,8 +96,24 @@ Organization Users.
 
 List all instance types:
 
+**CLI:**
+
 ```bash
 osac get instancetype
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.InstanceTypes/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/instance_types"
 ```
 
 The output shows each type in a table with the following columns:
@@ -85,8 +124,25 @@ The output shows each type in a table with the following columns:
 ACTIVE and DEPRECATED types are shown by default. OBSOLETE types are hidden
 from the default listing. To list only OBSOLETE types, filter by state:
 
+**CLI:**
+
 ```bash
 osac get instancetype --filter "state=OBSOLETE"
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"filter": "state=OBSOLETE"}' \
+  $OSAC_API osac.public.v1.InstanceTypes/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/instance_types?filter=state%3DOBSOLETE"
 ```
 
 ---
@@ -95,8 +151,25 @@ osac get instancetype --filter "state=OBSOLETE"
 
 View the full details of a specific instance type:
 
+**CLI:**
+
 ```bash
 osac describe instancetype standard-4-16
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "standard-4-16"}' \
+  $OSAC_API osac.public.v1.InstanceTypes/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/instance_types/standard-4-16"
 ```
 
 The output shows the instance type's name, cores, memory_gib, state,
@@ -113,12 +186,52 @@ types that are hidden from the default listing.
 
 Create an instance type with the desired compute specification:
 
+**CLI:**
+
 ```bash
 osac create instancetype \
   --name standard-4-16 \
   --cores 4 \
   --memory-gib 16 \
   --description "Balanced compute: 4 cores, 16 GiB RAM"
+```
+
+> **Note:** Instance type management uses the **private** admin API
+> (`osac.private.v1`). The examples below use the private API service name.
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "id": "standard-4-16",
+    "metadata": {
+      "name": "standard-4-16"
+    },
+    "spec": {
+      "cores": 4,
+      "memory_gib": 16,
+      "description": "Balanced compute: 4 cores, 16 GiB RAM"
+    }
+  }
+}' $OSAC_API osac.private.v1.InstanceTypes/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "id": "standard-4-16",
+  "metadata": {
+    "name": "standard-4-16"
+  },
+  "spec": {
+    "cores": 4,
+    "memory_gib": 16,
+    "description": "Balanced compute: 4 cores, 16 GiB RAM"
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/instance_types"
 ```
 
 The instance type is immediately available in ACTIVE state. Users can select
@@ -129,6 +242,8 @@ it when creating VMs.
 ### Deprecate an instance type
 
 To deprecate an instance type, edit it and change the state:
+
+**CLI:**
 
 ```bash
 osac edit instancetype standard-4-16
@@ -142,6 +257,39 @@ also set the following deprecation fields:
 - `spec.deprecation.obsolescence_timestamp` -- the timestamp when this type
   will become OBSOLETE.
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "id": "standard-4-16",
+    "spec": {
+      "state": "INSTANCE_TYPE_STATE_DEPRECATED",
+      "deprecation": {
+        "replacement": "standard-4-32"
+      }
+    }
+  },
+  "update_mask": {
+    "paths": ["spec.state", "spec.deprecation"]
+  }
+}' $OSAC_API osac.private.v1.InstanceTypes/Update
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "spec": {
+    "state": "INSTANCE_TYPE_STATE_DEPRECATED",
+    "deprecation": {
+      "replacement": "standard-4-32"
+    }
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/instance_types/standard-4-16?update_mask=spec.state,spec.deprecation"
+```
+
 Deprecation and obsolescence timestamps auto-populate when the state
 transitions. A DEPRECATED instance type remains available for VM creation,
 but users receive a warning indicating the type will be phased out.
@@ -152,6 +300,8 @@ but users receive a warning indicating the type will be phased out.
 
 To obsolete an instance type, edit it and change the state:
 
+**CLI:**
+
 ```bash
 osac edit instancetype standard-4-16
 ```
@@ -160,12 +310,41 @@ In the editor, change `spec.state` from `DEPRECATED` to `OBSOLETE`. VMs can
 no longer be created with an OBSOLETE instance type. Existing VMs that
 reference it are not affected.
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "id": "standard-4-16",
+    "spec": {
+      "state": "INSTANCE_TYPE_STATE_OBSOLETE"
+    }
+  },
+  "update_mask": {
+    "paths": ["spec.state"]
+  }
+}' $OSAC_API osac.private.v1.InstanceTypes/Update
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "spec": {
+    "state": "INSTANCE_TYPE_STATE_OBSOLETE"
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/instance_types/standard-4-16?update_mask=spec.state"
+```
+
 ---
 
 ### Reactivate an instance type
 
 Instance type state transitions are bidirectional. To reactivate a
 DEPRECATED or OBSOLETE instance type:
+
+**CLI:**
 
 ```bash
 osac edit instancetype standard-4-16
@@ -175,14 +354,58 @@ In the editor, change `spec.state` back to `ACTIVE`. The instance type
 becomes available for VM creation again. Transitions from OBSOLETE to
 DEPRECATED and from DEPRECATED to ACTIVE are both allowed.
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "id": "standard-4-16",
+    "spec": {
+      "state": "INSTANCE_TYPE_STATE_ACTIVE"
+    }
+  },
+  "update_mask": {
+    "paths": ["spec.state"]
+  }
+}' $OSAC_API osac.private.v1.InstanceTypes/Update
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X PATCH -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "spec": {
+    "state": "INSTANCE_TYPE_STATE_ACTIVE"
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/instance_types/standard-4-16?update_mask=spec.state"
+```
+
 ---
 
 ### Delete an instance type
 
 Delete an instance type that is no longer needed:
 
+**CLI:**
+
 ```bash
 osac delete instancetype standard-4-16
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "standard-4-16"}' \
+  $OSAC_API osac.private.v1.InstanceTypes/Delete
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/instance_types/standard-4-16"
 ```
 
 Deletion is only allowed when no ComputeInstances reference the instance
@@ -196,7 +419,9 @@ error. See [Troubleshooting](#cannot-delete-an-instance-type) for details.
 ### Selecting an instance type for VM creation
 
 When creating a ComputeInstance, specify the instance type using the
-`--instance-type` flag:
+`--instance-type` flag (CLI) or the `spec.instance_type` field (API):
+
+**CLI:**
 
 ```bash
 osac create computeinstance \
@@ -205,10 +430,10 @@ osac create computeinstance \
   ...
 ```
 
-For the full VM creation walkthrough, see the
-[ComputeInstance Guide](computeinstance-guide.md).
+**gRPC / REST:** See the `spec.instance_type` field in the
+[ComputeInstance Guide](computeinstance-guide.md#step-3-create-the-computeinstance).
 
-If you select a DEPRECATED instance type, a warning is printed to stderr
+If you select a DEPRECATED instance type, a warning is returned
 indicating the type will be phased out and suggesting the replacement (if one
 is configured). The VM is still created successfully.
 
@@ -226,8 +451,24 @@ The instance type is referenced by one or more ComputeInstances. Delete or
 migrate all VMs using this instance type before deleting it. To find which
 VMs are running:
 
+**CLI:**
+
 ```bash
 osac get computeinstance
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.ComputeInstances/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/compute_instances"
 ```
 
 Review the output and delete or recreate the VMs that reference the instance

--- a/guides/developer/networking-guide.md
+++ b/guides/developer/networking-guide.md
@@ -5,6 +5,10 @@ compute instances: VirtualNetworks and Subnets. It also covers SecurityGroups, w
 optional and only needed when you want to apply firewall rules. It assumes you already
 have a Tenant in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
 
+Each step shows the `osac` CLI command and the equivalent gRPC / REST API calls so that
+the same guide works for both CLI users and application developers integrating with
+OSAC's API.
+
 ## Contents
 
 - [Prerequisites](#prerequisites)
@@ -19,7 +23,26 @@ have a Tenant in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
 
 ## Prerequisites
 
+**CLI users:**
+
 - The `osac` CLI is installed and configured (API endpoint, authentication token).
+
+**API users:**
+
+- `grpcurl` (for gRPC) or `curl` (for REST) is installed.
+- Set the following environment variables for the examples in this guide:
+
+  ```bash
+  export OSAC_API="<api-endpoint>"    # host:port (e.g., fulfillment-api.osac.svc:443)
+  export TOKEN="<authentication-token>"
+
+  # Skip TLS verification in development environments:
+  # export GRPCURL_FLAGS="-insecure"
+  # export CURL_FLAGS="-k"
+  ```
+
+**Both:**
+
 - A Tenant is in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
 
 ---
@@ -52,8 +75,24 @@ NetworkClass (platform-defined, read-only)
 
 List the available network classes to find the one you will use for your VirtualNetwork:
 
+**CLI:**
+
 ```bash
 osac get networkclass
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.NetworkClasses/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/network_classes"
 ```
 
 Note the `ID` of the NetworkClass you want to use — you will need it in the next step.
@@ -65,6 +104,8 @@ Note the `ID` of the NetworkClass you want to use — you will need it in the ne
 Create a VirtualNetwork associated with the NetworkClass. The `--ipv4-cidr` defines the
 overall IP address range for the network:
 
+**CLI:**
+
 ```bash
 osac create virtualnetwork \
   --name <virtualnetwork_name> \
@@ -72,13 +113,75 @@ osac create virtualnetwork \
   --ipv4-cidr 192.168.0.0/16
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {
+      "name": "<virtualnetwork_name>"
+    },
+    "spec": {
+      "network_class": "<networkclass-id>",
+      "ipv4_cidr": "192.168.0.0/16",
+      "capabilities": {
+        "enable_ipv4": true
+      }
+    }
+  }
+}' $OSAC_API osac.public.v1.VirtualNetworks/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {
+    "name": "<virtualnetwork_name>"
+  },
+  "spec": {
+    "network_class": "<networkclass-id>",
+    "ipv4_cidr": "192.168.0.0/16",
+    "capabilities": {
+      "enable_ipv4": true
+    }
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/virtual_networks"
+```
+
+> **Note (API users):** The REST body is the VirtualNetwork object directly.
+> The gRPC request wraps it in an `object` field. The `capabilities` field is
+> derived automatically by the CLI; when calling the API directly, set
+> `enable_ipv4`, `enable_ipv6`, or `enable_dual_stack` to match the CIDRs
+> you provide.
+
 Note the VirtualNetwork `ID` from the output — you will need it when creating Subnets
 and SecurityGroups.
 
-Wait for the VirtualNetwork to reach `READY` state:
+Wait for the VirtualNetwork to reach `READY` state. Provisioning is
+asynchronous — rerun the command until the status shows `READY` before
+proceeding:
+
+**CLI:**
 
 ```bash
-osac get virtualnetwork
+osac get virtualnetwork <virtualnetwork_name>
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<virtualnetwork-id>"}' \
+  $OSAC_API osac.public.v1.VirtualNetworks/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/virtual_networks/<virtualnetwork-id>"
 ```
 
 ---
@@ -88,6 +191,8 @@ osac get virtualnetwork
 Create a Subnet under the VirtualNetwork. The Subnet CIDR must fall within the
 VirtualNetwork's CIDR range (e.g., `192.168.1.0/24` is within `192.168.0.0/16`):
 
+**CLI:**
+
 ```bash
 osac create subnet \
   --name <subnet_name> \
@@ -95,12 +200,65 @@ osac create subnet \
   --ipv4-cidr 192.168.1.0/24
 ```
 
-Note the Subnet `ID` from the output — you will need it when creating compute instances.
+> **Note:** The CLI accepts a VirtualNetwork name or ID for the `--virtual-network`
+> flag and resolves it to the VirtualNetwork's UUID. When calling the API directly,
+> use the VirtualNetwork UUID.
 
-Wait for the Subnet to reach `READY` state:
+**gRPC:**
 
 ```bash
-osac get subnet
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {
+      "name": "<subnet_name>"
+    },
+    "spec": {
+      "virtual_network": "<virtualnetwork-id>",
+      "ipv4_cidr": "192.168.1.0/24"
+    }
+  }
+}' $OSAC_API osac.public.v1.Subnets/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {
+    "name": "<subnet_name>"
+  },
+  "spec": {
+    "virtual_network": "<virtualnetwork-id>",
+    "ipv4_cidr": "192.168.1.0/24"
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/subnets"
+```
+
+Note the Subnet `ID` from the output — you will need it when creating compute instances.
+
+Wait for the Subnet to reach `READY` state. Provisioning is asynchronous —
+rerun the command until the status shows `READY` before proceeding:
+
+**CLI:**
+
+```bash
+osac get subnet <subnet_name>
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<subnet-id>"}' \
+  $OSAC_API osac.public.v1.Subnets/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/subnets/<subnet-id>"
 ```
 
 ---
@@ -116,6 +274,14 @@ traffic to and from compute instances. They are scoped to a VirtualNetwork and f
 Use `--ingress` and `--egress` flags to define rules. Each rule is a comma-separated
 list of `key=value` pairs:
 
+> **Warning — development only:** The examples below use `0.0.0.0/0` (all
+> IPv4 addresses) for convenience. This exposes ports to the public
+> internet. In production, replace `0.0.0.0/0` with a restricted CIDR
+> that limits access to your administrator or application networks (e.g.,
+> `10.0.0.0/8` or your corporate VPN range).
+
+**CLI:**
+
 ```bash
 osac create securitygroup \
   --name <securitygroup_name> \
@@ -126,16 +292,84 @@ osac create securitygroup \
   --egress protocol=all,ipv4-cidr=0.0.0.0/0
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {
+      "name": "<securitygroup_name>"
+    },
+    "spec": {
+      "virtual_network": "<virtualnetwork-id>",
+      "ingress": [
+        {"protocol": "PROTOCOL_TCP", "port_from": 22, "port_to": 22, "ipv4_cidr": "0.0.0.0/0"},
+        {"protocol": "PROTOCOL_TCP", "port_from": 80, "port_to": 80, "ipv4_cidr": "0.0.0.0/0"},
+        {"protocol": "PROTOCOL_TCP", "port_from": 443, "port_to": 443, "ipv4_cidr": "0.0.0.0/0"}
+      ],
+      "egress": [
+        {"protocol": "PROTOCOL_ALL", "ipv4_cidr": "0.0.0.0/0"}
+      ]
+    }
+  }
+}' $OSAC_API osac.public.v1.SecurityGroups/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {
+    "name": "<securitygroup_name>"
+  },
+  "spec": {
+    "virtual_network": "<virtualnetwork-id>",
+    "ingress": [
+      {"protocol": "PROTOCOL_TCP", "port_from": 22, "port_to": 22, "ipv4_cidr": "0.0.0.0/0"},
+      {"protocol": "PROTOCOL_TCP", "port_from": 80, "port_to": 80, "ipv4_cidr": "0.0.0.0/0"},
+      {"protocol": "PROTOCOL_TCP", "port_from": 443, "port_to": 443, "ipv4_cidr": "0.0.0.0/0"}
+    ],
+    "egress": [
+      {"protocol": "PROTOCOL_ALL", "ipv4_cidr": "0.0.0.0/0"}
+    ]
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/security_groups"
+```
+
+> **Note (API users):** Protocol values in the API use the enum names:
+> `PROTOCOL_TCP`, `PROTOCOL_UDP`, `PROTOCOL_ICMP`, `PROTOCOL_ALL`. The CLI
+> accepts the short forms `tcp`, `udp`, `icmp`, `all`.
+
 The example above allows inbound SSH (port 22), HTTP (port 80), and HTTPS (port 443)
 from any IPv4 address, and permits all outbound traffic.
 
 Note the SecurityGroup `ID` from the output — you will need it when creating compute
 instances.
 
-Wait for the SecurityGroup to reach `READY` state:
+Wait for the SecurityGroup to reach `READY` state. Provisioning is
+asynchronous — rerun the command until the status shows `READY` before
+proceeding:
+
+**CLI:**
 
 ```bash
-osac get securitygroup
+osac get securitygroup <securitygroup_name>
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<securitygroup-id>"}' \
+  $OSAC_API osac.public.v1.SecurityGroups/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/security_groups/<securitygroup-id>"
 ```
 
 ### Rule format
@@ -143,22 +377,25 @@ osac get securitygroup
 Each `--ingress` or `--egress` flag takes a rule in `key=value,...` format with the
 following keys:
 
-| Key | Required | Description |
-|-----|----------|-------------|
-| `protocol` | Yes | One of: `tcp`, `udp`, `icmp`, `all` |
-| `port-from` | For `tcp`/`udp` | Start of port range (1–65535) |
-| `port-to` | For `tcp`/`udp` | End of port range (1–65535), must be >= `port-from` |
-| `ipv4-cidr` | No | IPv4 CIDR block (e.g., `0.0.0.0/0` for all, `10.0.0.0/8` for private) |
-| `ipv6-cidr` | No | IPv6 CIDR block (e.g., `::/0` for all) |
+| Key | Required | Description | API enum / field |
+|-----|----------|-------------|------------------|
+| `protocol` | Yes | One of: `tcp`, `udp`, `icmp`, `all` | `PROTOCOL_TCP`, `PROTOCOL_UDP`, `PROTOCOL_ICMP`, `PROTOCOL_ALL` |
+| `port-from` | For `tcp`/`udp` | Start of port range (1–65535) | `port_from` |
+| `port-to` | For `tcp`/`udp` | End of port range (1–65535), must be >= `port-from` | `port_to` |
+| `ipv4-cidr` | No | IPv4 CIDR block (e.g., `0.0.0.0/0` for all, `10.0.0.0/8` for private) | `ipv4_cidr` |
+| `ipv6-cidr` | No | IPv6 CIDR block (e.g., `::/0` for all) | `ipv6_cidr` |
 
 - For `icmp` and `all` protocols, port fields are ignored.
 - Both `ipv4-cidr` and `ipv6-cidr` can be set on a single rule to create a dual-stack
   rule.
 - The `--ingress` and `--egress` flags can each be repeated to add multiple rules.
+  In the API, use arrays of rule objects.
 
 ### Examples
 
 Allow only SSH from a specific network:
+
+**CLI:**
 
 ```bash
 osac create securitygroup \
@@ -167,7 +404,43 @@ osac create securitygroup \
   --ingress protocol=tcp,port-from=22,port-to=22,ipv4-cidr=10.0.0.0/8
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {"name": "ssh-only"},
+    "spec": {
+      "virtual_network": "<virtualnetwork-id>",
+      "ingress": [
+        {"protocol": "PROTOCOL_TCP", "port_from": 22, "port_to": 22, "ipv4_cidr": "10.0.0.0/8"}
+      ]
+    }
+  }
+}' $OSAC_API osac.public.v1.SecurityGroups/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {"name": "ssh-only"},
+  "spec": {
+    "virtual_network": "<virtualnetwork-id>",
+    "ingress": [
+      {"protocol": "PROTOCOL_TCP", "port_from": 22, "port_to": 22, "ipv4_cidr": "10.0.0.0/8"}
+    ]
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/security_groups"
+```
+
 Allow all traffic (open security group):
+
+> **Warning — development only:** This creates a fully open security
+> group. Do not use `0.0.0.0/0` with `PROTOCOL_ALL` in production.
+
+**CLI:**
 
 ```bash
 osac create securitygroup \
@@ -177,7 +450,42 @@ osac create securitygroup \
   --egress protocol=all,ipv4-cidr=0.0.0.0/0
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {"name": "allow-all"},
+    "spec": {
+      "virtual_network": "<virtualnetwork-id>",
+      "ingress": [{"protocol": "PROTOCOL_ALL", "ipv4_cidr": "0.0.0.0/0"}],
+      "egress": [{"protocol": "PROTOCOL_ALL", "ipv4_cidr": "0.0.0.0/0"}]
+    }
+  }
+}' $OSAC_API osac.public.v1.SecurityGroups/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {"name": "allow-all"},
+  "spec": {
+    "virtual_network": "<virtualnetwork-id>",
+    "ingress": [{"protocol": "PROTOCOL_ALL", "ipv4_cidr": "0.0.0.0/0"}],
+    "egress": [{"protocol": "PROTOCOL_ALL", "ipv4_cidr": "0.0.0.0/0"}]
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/security_groups"
+```
+
 Allow a range of UDP ports:
+
+> **Warning — development only:** This example uses `0.0.0.0/0` (all
+> IPv4 addresses). In production, replace it with a restricted CIDR
+> that limits access to trusted networks.
+
+**CLI:**
 
 ```bash
 osac create securitygroup \
@@ -186,13 +494,61 @@ osac create securitygroup \
   --ingress protocol=udp,port-from=5000,port-to=5100,ipv4-cidr=0.0.0.0/0
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {"name": "udp-range"},
+    "spec": {
+      "virtual_network": "<virtualnetwork-id>",
+      "ingress": [
+        {"protocol": "PROTOCOL_UDP", "port_from": 5000, "port_to": 5100, "ipv4_cidr": "0.0.0.0/0"}
+      ]
+    }
+  }
+}' $OSAC_API osac.public.v1.SecurityGroups/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {"name": "udp-range"},
+  "spec": {
+    "virtual_network": "<virtualnetwork-id>",
+    "ingress": [
+      {"protocol": "PROTOCOL_UDP", "port_from": 5000, "port_to": 5100, "ipv4_cidr": "0.0.0.0/0"}
+    ]
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/security_groups"
+```
+
 ### Inspect a security group
+
+**CLI:**
 
 ```bash
 osac describe securitygroup <securitygroup-name-or-id>
 ```
 
-This displays the security group's state and a table of all ingress and egress rules.
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<securitygroup-id>"}' \
+  $OSAC_API osac.public.v1.SecurityGroups/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/security_groups/<securitygroup-id>"
+```
+
+This displays the security group's state and all ingress and egress rules.
 
 ---
 

--- a/guides/developer/publicip-guide.md
+++ b/guides/developer/publicip-guide.md
@@ -5,6 +5,10 @@ running ComputeInstance so that it becomes reachable from outside the cluster.
 It covers the full lifecycle: pool discovery, IP allocation, attachment,
 detachment, and release.
 
+Each step shows the `osac` CLI command and the equivalent gRPC / REST API
+calls so that the same guide works for both CLI users and application
+developers integrating with OSAC's API.
+
 For background on why PublicIPs are needed and how they work under the hood,
 see the [PublicIP Networking Architecture](../../architecture/publicip-networking.md).
 
@@ -56,14 +60,34 @@ that the provider has made available.
 
 ## Prerequisites
 
+**CLI users:**
+
 - The `osac` CLI is installed and configured (API endpoint, authentication token).
+
+**API users:**
+
+- `grpcurl` (for gRPC) or `curl` (for REST) is installed.
+- Set the following environment variables for the examples in this guide:
+
+  ```bash
+  export OSAC_API="<api-endpoint>"    # host:port (e.g., fulfillment-api.osac.svc:443)
+  export TOKEN="<authentication-token>"
+
+  # Skip TLS verification in development environments:
+  # export GRPCURL_FLAGS="-insecure"
+  # export CURL_FLAGS="-k"
+  ```
+
+**Both:**
+
 - A Tenant is in `Ready` state (see [Tenant Setup Guide](tenant-setup.md)).
 - A ComputeInstance is in `RUNNING` state (see [ComputeInstance Guide](computeinstance-guide.md)).
 - At least one PublicIPPool has been created by the cloud provider.
 
 > **Tip:** Wherever this guide uses a resource name (e.g., `<pool-name>`),
 > you can also use its UUID. The `osac` CLI accepts either form when
-> referencing existing resources.
+> referencing existing resources. When calling the API directly, use the
+> resource UUID.
 
 ---
 
@@ -71,15 +95,31 @@ that the provider has made available.
 
 List the pools that are visible to your tenant:
 
+**CLI:**
+
 ```bash
 osac get publicippool
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.PublicIPPools/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/public_ip_pools"
 ```
 
 The output shows each pool's IP family, CIDR ranges, and how many addresses are
 still available. Choose a pool that matches the address family you need (IPv4
 or IPv6) and has available capacity.
 
-Note the **name** of the pool you want to use.
+Note the **name** (or **ID**) of the pool you want to use.
 
 ---
 
@@ -87,22 +127,73 @@ Note the **name** of the pool you want to use.
 
 Allocate an address from the chosen pool:
 
+**CLI:**
+
 ```bash
 osac create publicip \
   --name <publicip-name> \
   --pool <pool-name>
 ```
 
+> **Note:** The CLI accepts a pool name or ID for the `--pool` flag and
+> resolves it to the pool's UUID. When calling the API directly, use the
+> pool UUID.
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "metadata": {
+      "name": "<publicip-name>"
+    },
+    "spec": {
+      "pool": "<pool-id>"
+    }
+  }
+}' $OSAC_API osac.public.v1.PublicIPs/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "metadata": {
+    "name": "<publicip-name>"
+  },
+  "spec": {
+    "pool": "<pool-id>"
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/public_ips"
+```
+
 The PublicIP starts in `PENDING` state while the system reserves an address.
 Wait for it to reach `ALLOCATED`:
+
+**CLI:**
 
 ```bash
 osac get publicip
 ```
 
-Once allocated, the output shows the assigned address in the `ADDRESS` column.
-The IP is now reserved for your tenant but is not yet routing traffic to any
-resource.
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.PublicIPs/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/public_ips"
+```
+
+Once allocated, the output shows the assigned address in the `ADDRESS` column
+(CLI) or the `status.address` field (API). The IP is now reserved for your
+tenant but is not yet routing traffic to any resource.
 
 > **Note:** The `--pool` field is immutable. A PublicIP cannot be moved to a
 > different pool after creation. To use a different pool, delete this PublicIP
@@ -115,6 +206,8 @@ resource.
 Create a PublicIPAttachment to bind the allocated IP to a running
 ComputeInstance:
 
+**CLI:**
+
 ```bash
 osac create publicipattachment \
   --name <attachment-name> \
@@ -122,16 +215,61 @@ osac create publicipattachment \
   --compute-instance <computeinstance-name>
 ```
 
+> **Note:** The CLI accepts names or IDs for both `--public-ip` and
+> `--compute-instance` and resolves them to UUIDs. When calling the API
+> directly, use the resource UUIDs.
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" -d '{
+  "object": {
+    "spec": {
+      "public_ip": "<publicip-id>",
+      "compute_instance": "<computeinstance-id>"
+    }
+  }
+}' $OSAC_API osac.public.v1.PublicIPAttachments/Create
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X POST -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" -d '{
+  "spec": {
+    "public_ip": "<publicip-id>",
+    "compute_instance": "<computeinstance-id>"
+  }
+}' "https://$OSAC_API/api/fulfillment/v1/public_ip_attachments"
+```
+
 The attachment starts in `PENDING` state while the system configures network
 routing. Wait for it to reach `READY`:
+
+**CLI:**
 
 ```bash
 osac get publicipattachment
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  $OSAC_API osac.public.v1.PublicIPAttachments/List
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/public_ip_attachments"
+```
+
 When the attachment is `READY`, external clients can reach the ComputeInstance
 at the public IP address. The PublicIP's status also updates to show
-`ATTACHED: true`.
+`ATTACHED: true` (CLI) or `"attached": true` (API).
 
 > **Constraints:**
 > - Each PublicIP can have at most one attachment at a time.
@@ -165,26 +303,107 @@ nc -zv <public-ip-address> 22
 Delete the PublicIPAttachment to stop routing traffic to the ComputeInstance
 while keeping the IP address allocated:
 
+**CLI:**
+
 ```bash
 osac delete publicipattachment <attachment-name>
 ```
 
-The PublicIP remains in `ALLOCATED` state with `ATTACHED: false`. You can
-create a new PublicIPAttachment to attach it to a different ComputeInstance.
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<attachment-id>"}' \
+  $OSAC_API osac.public.v1.PublicIPAttachments/Delete
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/public_ip_attachments/<attachment-id>"
+```
+
+Detachment is asynchronous. Poll the PublicIP until it reports
+`ATTACHED: false` (CLI) or `"attached": false` (API) before treating
+the IP as detached or creating a new attachment:
+
+**CLI:**
+
+```bash
+osac get publicip <publicip-name>
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<publicip-id>"}' \
+  $OSAC_API osac.public.v1.PublicIPs/Get
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/public_ips/<publicip-id>"
+```
+
+Once the PublicIP shows `ATTACHED: false`, it remains in `ALLOCATED` state
+and you can create a new PublicIPAttachment to attach it to a different
+ComputeInstance.
 
 ### Release the IP (return it to the pool)
 
 First detach the IP if it is currently attached (a PublicIP cannot be deleted
 while attached):
 
+**CLI:**
+
 ```bash
 osac delete publicipattachment <attachment-name>
 ```
 
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<attachment-id>"}' \
+  $OSAC_API osac.public.v1.PublicIPAttachments/Delete
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/public_ip_attachments/<attachment-id>"
+```
+
+Wait for the detachment to complete before deleting the PublicIP. Poll the
+PublicIP until it reports `ATTACHED: false` — see the polling commands in
+[Detach only](#detach-only-keep-the-ip-reserved) above.
+
 Then delete the PublicIP to return the address to the pool:
+
+**CLI:**
 
 ```bash
 osac delete publicip <publicip-name>
+```
+
+**gRPC:**
+
+```bash
+grpcurl $GRPCURL_FLAGS -H "Authorization: Bearer $TOKEN" \
+  -d '{"id": "<publicip-id>"}' \
+  $OSAC_API osac.public.v1.PublicIPs/Delete
+```
+
+**REST:**
+
+```bash
+curl -fsS $CURL_FLAGS -X DELETE -H "Authorization: Bearer $TOKEN" \
+  "https://$OSAC_API/api/fulfillment/v1/public_ips/<publicip-id>"
 ```
 
 The address becomes available for other tenants to allocate.


### PR DESCRIPTION
Add grpcurl and curl examples alongside every osac CLI command in the five API-facing developer guides so the same documents serve both CLI users and application developers integrating with OSAC's gRPC/REST API.

TLS flags are provided via $GRPCURL_FLAGS and $CURL_FLAGS environment variables so they can be set once for dev environments or left unset for production.

Assisted-by: Claude Code <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated ComputeInstance, computeinstance catalog item, instance type, networking, and public IP guides to provide parallel OSAC CLI, gRPC, and REST workflows for browsing, create/manage, and monitoring.
  - Added API-oriented prerequisites (endpoint/auth/TLS), multi-protocol request examples, and clearer field mappings (including `field_definitions` override behavior and editable/non-editable guidance).
  - Expanded administrative lifecycle examples (including private admin operations and update-mask PATCH usage) and enhanced troubleshooting with protocol-specific commands.
  - Clarified limits, including CLI-only interactive console access and differences in request/response shapes for networking and security group rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->