### PR TITLE
OSAC-1580: Add Keycloak operator configuration and upgrade/rollback guides

### DIFF
--- a/guides/keycloak-configuration.md
+++ b/guides/keycloak-configuration.md
@@ -1,0 +1,333 @@
+# OSAC Keycloak Configuration
+
+This guide documents the OSAC-specific Keycloak configuration: the "osac" realm,
+required clients, custom scopes, group-based multi-tenancy, and how OSAC services
+integrate with Keycloak. For general Keycloak installation and administration, see
+the [Keycloak documentation](https://www.keycloak.org/documentation).
+
+## Table of Contents
+
+- [Overview](#overview)
+- [OSAC Realm](#osac-realm)
+  - [Clients](#clients)
+  - [Client Scopes](#client-scopes)
+  - [Groups and Multi-Tenancy](#groups-and-multi-tenancy)
+  - [Realm Roles](#realm-roles)
+- [Integration with OSAC Services](#integration-with-osac-services)
+  - [Fulfillment Service Authentication](#fulfillment-service-authentication)
+  - [Controller Credentials](#controller-credentials)
+  - [CLI Authentication](#cli-authentication)
+  - [Helm Values](#helm-values)
+  - [Verification](#verification)
+- [Deployment via OLM](#deployment-via-olm)
+  - [Operator Installation](#operator-installation)
+  - [Keycloak Instance](#keycloak-instance)
+  - [Realm Import](#realm-import)
+- [Upgrade Notes](#upgrade-notes)
+- [BYO Keycloak](#byo-keycloak)
+
+---
+
+## Overview
+
+OSAC uses Keycloak as its identity provider for OAuth 2.0 / OpenID Connect
+authentication. All OSAC services authenticate against a single realm named
+`osac`. The realm defines:
+
+- **Clients** for the CLI, controller, and admin tools
+- **Client scopes** that add OSAC-specific claims (audience, username, groups) to tokens
+- **Groups** that map to OSAC tenants for multi-tenant isolation
+- **Realm roles** for authorization (e.g., `tenant-admin`)
+
+The authoritative realm definition lives in the
+[fulfillment-service](https://github.com/osac-project/fulfillment-service)
+repository at `it/charts/keycloak/files/realm.json`. The
+[osac-installer](https://github.com/osac-project/osac-installer) maintains a
+deployment-ready copy at `prerequisites/keycloak/files/realm.json`.
+
+---
+
+## OSAC Realm
+
+Realm name: **`osac`**
+
+### Clients
+
+OSAC defines three application-specific clients. Standard Keycloak clients
+(`account`, `admin-cli`, `broker`, etc.) are also present with default settings.
+
+| Client ID | Type | Auth Method | Purpose |
+|-----------|------|-------------|---------|
+| `osac-cli` | Public | Direct access grants (password flow) | CLI tool authentication for end users |
+| `osac-controller` | Confidential | Client credentials (service account) | Fulfillment controller → fulfillment API |
+| `osac-admin` | Confidential | Client credentials (service account) | Administrative operations |
+
+#### osac-cli
+
+- **Public client** — no client secret required
+- **Direct access grants enabled** — supports username/password login from the CLI
+- **Redirect URI:** `http://localhost` (for local CLI callback)
+- **Default scopes:** `groups`, `basic`, `username`, `organization`, `roles`, `osac-api`
+- **Token claims:** username, group membership, `osac-api` audience
+
+#### osac-controller
+
+- **Confidential client** — requires a client secret
+- **Service account enabled** — authenticates via client credentials grant
+- **Service account username:** `service-account-osac-controller`
+- **Client roles (realm-management):** `manage-realm`, `manage-users`, `view-realm`,
+  `view-users`, `manage-identity-providers`, `view-identity-providers`
+- **Default scopes:** standard Keycloak scopes (web-origins, profile, roles, email)
+
+The controller's client secret is extracted from `realm.json` and stored in a
+Kubernetes Secret (`fulfillment-controller-credentials`). The OPA authorization
+policy expects the JWT `preferred_username` to be `service-account-osac-controller`.
+
+#### osac-admin
+
+- **Confidential client** — requires a client secret
+- **Service account enabled** — authenticates via client credentials grant
+- **Default scopes:** standard scopes plus `osac-api`
+- **Token claims:** includes `osac-api` audience (required for API access)
+
+### Client Scopes
+
+Three custom client scopes add OSAC-specific claims to access tokens:
+
+| Scope | Mapper Type | Claim | Description |
+|-------|------------|-------|-------------|
+| `osac-api` | Audience mapper | `aud: "osac-api"` | Adds the `osac-api` audience to access tokens. Required for the fulfillment API to accept the token. |
+| `username` | User attribute mapper | `username` | Adds the user's username as a top-level claim in the token. |
+| `groups` | Group membership mapper | `groups` | Adds the user's group memberships as an array claim. Used for tenant-scoped authorization. |
+
+All three scopes are assigned as **default scopes** on the `osac-cli` client,
+ensuring CLI tokens always contain these claims.
+
+### Groups and Multi-Tenancy
+
+OSAC maps Keycloak groups to tenants. Each group represents a tenant, and users
+are assigned to groups to grant access to that tenant's resources.
+
+| Group | Purpose |
+|-------|---------|
+| `admins` | Platform administrators |
+| `tenant1` | Test tenant 1 |
+| `tenant2` | Test tenant 2 |
+| `my_group` | Test group |
+| `your_group` | Test group |
+
+The `groups` claim in the JWT token carries the user's group memberships. The
+fulfillment service uses this claim to enforce tenant isolation — users can only
+access resources belonging to their group(s).
+
+Users can belong to multiple groups (e.g., the `twotenant` test user belongs to
+both `tenant1` and `tenant2`).
+
+### Realm Roles
+
+| Role | Description |
+|------|-------------|
+| `tenant-admin` | Grants elevated permissions within a tenant (e.g., managing users, creating resources) |
+| `default-roles-my realm` | Composite role assigned to all users (includes `offline_access`, `uma_authorization`, `view-profile`, `manage-account`) |
+
+---
+
+## Integration with OSAC Services
+
+### Fulfillment Service Authentication
+
+The fulfillment service validates JWTs issued by Keycloak. It connects to
+Keycloak using these configuration values:
+
+| Setting | Value | Description |
+|---------|-------|-------------|
+| `auth.issuerUrl` | `https://keycloak.keycloak.svc.cluster.local/realms/osac` | OIDC issuer URL for token validation |
+| `idp.provider` | `keycloak` | Identity provider type |
+| `idp.url` | `https://keycloak.keycloak.svc.cluster.local` | Keycloak base URL for admin operations |
+
+The fulfillment service fetches the OIDC discovery document from
+`{issuerUrl}/.well-known/openid-configuration` to discover JWKS endpoints for
+token signature verification.
+
+### Controller Credentials
+
+The fulfillment controller authenticates to the fulfillment API using the
+`osac-controller` client's credentials:
+
+```bash
+# Extract the client secret from realm.json
+FC_CLIENT_SECRET=$(jq -r \
+  '.clients[] | select(.clientId == "osac-controller") | .secret' \
+  prerequisites/keycloak/files/realm.json)
+
+# Create the Kubernetes secret
+oc create secret generic fulfillment-controller-credentials \
+  --from-literal=client-id=osac-controller \
+  --from-literal=client-secret="${FC_CLIENT_SECRET}" \
+  -n ${NAMESPACE} --dry-run=client -o yaml | oc apply -f -
+```
+
+### CLI Authentication
+
+The `osac` CLI authenticates using the `osac-cli` public client with the
+password grant flow:
+
+```bash
+# The CLI prompts for username/password and obtains a token from:
+# https://keycloak.keycloak.svc.cluster.local/realms/osac/protocol/openid-connect/token
+osac login --username tenant1_admin
+```
+
+### Helm Values
+
+Configure the fulfillment service Helm chart to point to Keycloak:
+
+```yaml
+service:
+  auth:
+    issuerUrl: https://keycloak.keycloak.svc.cluster.local/realms/osac
+    controllerCredentials:
+      secretName: fulfillment-controller-credentials
+  idp:
+    provider: keycloak
+    url: https://keycloak.keycloak.svc.cluster.local
+```
+
+These values are set in `osac-installer/values/*/values.yaml` and passed
+during `helm upgrade --install`.
+
+### Verification
+
+After deploying Keycloak and the fulfillment service, verify the integration:
+
+```bash
+# 1. Check the Keycloak realm is accessible
+curl -sk https://keycloak.keycloak.svc.cluster.local/realms/osac \
+  | jq .realm
+# Expected: "osac"
+
+# 2. Obtain a token using the CLI client
+TOKEN=$(curl -sk \
+  https://keycloak.keycloak.svc.cluster.local/realms/osac/protocol/openid-connect/token \
+  -d "client_id=osac-cli" \
+  -d "username=tenant1_admin" \
+  -d "password=foobar" \
+  -d "grant_type=password" | jq -r .access_token)
+
+# 3. Inspect the token claims
+echo $TOKEN | cut -d. -f2 | base64 -d 2>/dev/null | jq '{username, groups, aud}'
+# Expected: username=tenant1_admin, groups=["/tenant1"], aud includes "osac-api"
+
+# 4. Call the fulfillment API
+curl -sk -H "Authorization: Bearer $TOKEN" \
+  https://fulfillment-api-${NAMESPACE}.${DOMAIN}/v1/tenants
+```
+
+---
+
+## Deployment via OLM
+
+OSAC deploys Keycloak using the upstream Keycloak Operator via OLM (Operator
+Lifecycle Manager). This section summarizes the deployment; for full details
+see the [osac-installer prerequisites](https://github.com/osac-project/osac-installer/tree/main/prerequisites/keycloak).
+
+### Operator Installation
+
+```bash
+# Apply the OLM manifests (Namespace + OperatorGroup + Subscription)
+oc apply -f prerequisites/keycloak/operator.yaml
+
+# Wait for the operator CSV to succeed
+until KC_CSV=$(oc get csv --no-headers -n keycloak 2>/dev/null \
+  | awk '/keycloak/ { print $1 }' | tail -1) && [[ -n "${KC_CSV}" ]]; do
+  sleep 10
+done
+oc wait csv/${KC_CSV} -n keycloak \
+  --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+```
+
+The Subscription pins to a specific operator version via `startingCSV` with
+`installPlanApproval: Manual` for controlled upgrades.
+
+### Keycloak Instance
+
+```bash
+# Deploy the PostgreSQL database
+oc apply -k prerequisites/keycloak/database/
+
+# Deploy the Keycloak CR, TLS certificate, and Route
+oc apply -f prerequisites/keycloak/keycloak-instance.yaml
+
+# Wait for the Keycloak CR to be ready
+oc wait keycloak/osac-keycloak -n keycloak \
+  --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=True \
+  --timeout=600s
+```
+
+The operator creates a Service named `osac-keycloak-service` (derived from the
+CR name `osac-keycloak`) on port 8443 (HTTPS).
+
+### Realm Import
+
+The OSAC realm is imported via a `KeycloakRealmImport` CR generated dynamically
+from `realm.json`:
+
+```bash
+jq -n --arg realm "$(cat prerequisites/keycloak/files/realm.json)" '{
+    apiVersion: "k8s.keycloak.org/v2beta1",
+    kind: "KeycloakRealmImport",
+    metadata: {name: "osac-realm-import", namespace: "keycloak"},
+    spec: {keycloakCRName: "osac-keycloak", realm: ($realm | fromjson)}
+}' | oc apply -f -
+
+# Wait for the import to complete
+oc wait keycloakrealmimport/osac-realm-import -n keycloak \
+  --for=jsonpath='{.status.conditions[?(@.type=="Done")].status}'=True \
+  --timeout=300s
+```
+
+---
+
+## Upgrade Notes
+
+For the complete upgrade and rollback procedure — including database backup,
+operator upgrade via OLM, PostgreSQL version changes, and rollback steps — see
+the [Keycloak Upgrade and Rollback Runbook](keycloak-upgrade-rollback.md).
+
+Quick summary:
+
+1. **Back up the database** before upgrading (`pg_dump`)
+2. **Update the `startingCSV`** in `prerequisites/keycloak/operator.yaml` to the
+   new version
+3. **Approve the InstallPlan** (manual approval is required)
+4. **Wait for the Keycloak CR** to return to Ready state after the operator upgrade
+5. **Verify realm access** by checking the realm endpoint responds
+
+For upstream Keycloak upgrade guidance, see the
+[Keycloak Operator Upgrade Guide](https://www.keycloak.org/operator/upgrade).
+
+---
+
+## BYO Keycloak
+
+OSAC supports using an existing (Bring Your Own) Keycloak instance. Requirements:
+
+1. **Create an "osac" realm** with the clients, scopes, and groups described above
+2. **Configure the Helm values** to point to your Keycloak instance:
+
+```yaml
+service:
+  auth:
+    issuerUrl: https://your-keycloak.example.com/realms/osac
+  idp:
+    provider: keycloak
+    url: https://your-keycloak.example.com
+```
+
+3. **Create the controller credentials secret** with the `osac-controller` client
+   ID and secret from your realm
+4. **Ensure the `osac-api` audience scope** is configured on your clients — the
+   fulfillment service validates this audience in tokens
+
+The realm.json in the osac-installer repository can be imported into your
+Keycloak instance as a starting point, then customized for your environment.

--- a/guides/keycloak-upgrade-rollback.md
+++ b/guides/keycloak-upgrade-rollback.md
@@ -1,0 +1,521 @@
+# Keycloak Upgrade and Rollback Runbook
+
+This guide covers how to upgrade the OSAC Keycloak deployment (operator, server, and
+database) and how to roll back if something goes wrong. For general Keycloak
+configuration, see [keycloak-configuration.md](keycloak-configuration.md).
+
+## Table of Contents
+
+- [Overview](#overview)
+- [Pre-Upgrade Checklist](#pre-upgrade-checklist)
+- [Database Backup](#database-backup)
+- [Upgrade Procedure](#upgrade-procedure)
+  - [Operator Upgrade (OLM)](#operator-upgrade-olm)
+  - [PostgreSQL Upgrade](#postgresql-upgrade)
+- [Post-Upgrade Verification](#post-upgrade-verification)
+- [Rollback Procedure](#rollback-procedure)
+  - [When to Roll Back](#when-to-roll-back)
+  - [Full Rollback (Operator + Database)](#full-rollback-operator--database)
+  - [PostgreSQL-Only Rollback](#postgresql-only-rollback)
+- [Version Compatibility Matrix](#version-compatibility-matrix)
+
+---
+
+## Overview
+
+OSAC's Keycloak deployment has three independently versioned layers:
+
+| Layer | What changes | How it's controlled | Rollback path |
+|-------|-------------|--------------------|--------------------|
+| **Keycloak Operator** | Operator pod image | OLM `Subscription` with `installPlanApproval: Manual` | Uninstall + reinstall with previous `startingCSV` |
+| **Keycloak Server** | Keycloak pod image (StatefulSet) | Managed automatically by the operator — the operator version determines the server version | Restore DB from backup + reinstall old operator |
+| **PostgreSQL** | Database container image | Manual update in `prerequisites/keycloak/database/statefulset.yaml` | Revert the image tag (data on PVC is unchanged) |
+
+The operator and server versions move in lockstep — each operator release pins its
+own Keycloak server image. You cannot independently upgrade the server without
+upgrading the operator.
+
+**Key constraint**: Keycloak applies forward-only database migrations (via Liquibase)
+every time the server starts after an upgrade. These schema changes cannot be
+automatically undone. A database backup taken *before* the upgrade is the only way to
+roll back safely.
+
+---
+
+## Pre-Upgrade Checklist
+
+Run these checks before starting any upgrade.
+
+### 1. Record current versions
+
+```bash
+# Operator version (CSV)
+oc get csv -n keycloak -o custom-columns=NAME:.metadata.name,PHASE:.status.phase
+
+# Keycloak server image
+oc get pod -l app=keycloak -n keycloak \
+    -o jsonpath='{.items[0].spec.containers[0].image}'
+
+# PostgreSQL image
+oc get statefulset keycloak-database -n keycloak \
+    -o jsonpath='{.spec.template.spec.containers[0].image}'
+```
+
+Save the output — you will need these values if you need to roll back.
+
+### 2. Verify Keycloak is healthy
+
+```bash
+# Keycloak CR should be Ready
+oc get keycloak osac-keycloak -n keycloak \
+    -o jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
+# Expected: True
+
+# Realm import should be Done
+oc get keycloakrealmimport osac-realm-import -n keycloak \
+    -o jsonpath='{.status.conditions[?(@.type=="Done")].status}'
+# Expected: True
+```
+
+### 3. Verify fulfillment service is healthy
+
+```bash
+# All fulfillment pods should be Running
+oc get pods -n osac -l app.kubernetes.io/part-of=fulfillment-service --no-headers
+
+# Controller should have no recent auth errors
+oc logs deploy/fulfillment-controller -n osac --tail=20 | grep -i "error"
+```
+
+### 4. Check available storage
+
+Keycloak migrations may temporarily increase database size:
+
+```bash
+KC_DB_PASS=$(oc get secret keycloak-db-credentials -n keycloak \
+    -o jsonpath='{.data.password}' | base64 -d)
+
+oc exec keycloak-database-0 -n keycloak -- \
+    bash -c "PGPASSWORD='${KC_DB_PASS}' psql -h localhost -U keycloak \
+    -c \"SELECT pg_size_pretty(pg_database_size('keycloak'));\""
+```
+
+---
+
+## Database Backup
+
+Always back up the Keycloak database before upgrading the operator or server.
+
+### Create the backup
+
+The Keycloak database uses mTLS for TCP connections (`pg_hba.conf` requires
+client certificate auth). Use the `postgres` superuser via local unix socket
+instead of authenticating as `keycloak` over TCP:
+
+```bash
+BACKUP_FILE="keycloak-backup-$(date +%Y%m%d-%H%M%S).dump"
+
+oc exec keycloak-database-0 -n keycloak -c server -- \
+    pg_dump -U postgres -Fc keycloak \
+    > "${BACKUP_FILE}"
+
+echo "Backup saved to ${BACKUP_FILE} ($(du -h "${BACKUP_FILE}" | cut -f1))"
+```
+
+The `-Fc` flag creates a custom-format dump that supports selective restore and
+compression. The `-c server` flag selects the database container (the
+StatefulSet also has a `password-generator` init container).
+
+> **Note:** The `PGPASSWORD` + `-h localhost` approach documented in some
+> guides does not work when `pg_hba.conf` is configured for `hostssl cert`
+> authentication. The unix socket approach bypasses TCP authentication entirely
+> using the `postgres` superuser's `local peer` entry.
+
+### Verify the backup
+
+Verification must run inside the postgres container (the host may not have a
+compatible `pg_restore`):
+
+```bash
+oc cp "${BACKUP_FILE}" keycloak/keycloak-database-0:/tmp/backup-verify.dump -c server
+oc exec keycloak-database-0 -n keycloak -c server -- \
+    pg_restore --list /tmp/backup-verify.dump | head -20
+```
+
+You should see a table of contents listing Keycloak tables (e.g., `realm`,
+`client`, `user_entity`, `credential`). If this command fails, the backup is
+corrupt — do not proceed with the upgrade.
+
+### Backup retention
+
+Keep at least the last two backups. Store them off-cluster if possible (e.g.,
+on the bastion host or an object store).
+
+---
+
+## Upgrade Procedure
+
+### Operator Upgrade (OLM)
+
+The Keycloak operator is installed via OLM with `installPlanApproval: Manual`. OLM
+creates an `InstallPlan` when a new version is available in the channel, but does not
+apply it until you approve.
+
+#### Step 1: Check for pending upgrades
+
+```bash
+oc get installplan -n keycloak
+```
+
+A pending upgrade shows `APPROVED=false`:
+
+```
+NAME            CSV                           APPROVED
+install-abc12   keycloak-operator.v26.7.0     false
+```
+
+If no pending InstallPlan exists and you want to upgrade to a specific version,
+update the `startingCSV` in `prerequisites/keycloak/operator.yaml`:
+
+```yaml
+spec:
+  startingCSV: keycloak-operator.v26.7.0   # new target version
+```
+
+Then re-apply:
+
+```bash
+oc apply -f prerequisites/keycloak/operator.yaml
+```
+
+#### Step 2: Back up the database
+
+See [Database Backup](#database-backup) above. Do not skip this step.
+
+#### Step 3: Approve the InstallPlan
+
+```bash
+PLAN_NAME=$(oc get installplan -n keycloak \
+    -o jsonpath='{.items[?(@.spec.approved==false)].metadata.name}')
+
+oc patch installplan "${PLAN_NAME}" -n keycloak \
+    --type=merge -p '{"spec":{"approved":true}}'
+```
+
+#### Step 4: Wait for the new operator to be ready
+
+```bash
+# Wait for the new CSV to reach Succeeded
+oc wait csv -n keycloak -l operators.coreos.com/keycloak-operator.keycloak= \
+    --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+
+# The operator automatically updates the Keycloak StatefulSet image.
+# Wait for the Keycloak pod to restart with the new version.
+oc rollout status statefulset/osac-keycloak -n keycloak --timeout=600s
+```
+
+#### Step 5: Wait for database migrations
+
+The new Keycloak server runs Liquibase migrations on startup. This can take a few
+minutes depending on the version gap. Watch the Keycloak pod logs:
+
+```bash
+oc logs -f statefulset/osac-keycloak -n keycloak | grep -i "liquibase\|migrat"
+```
+
+Wait until you see `Keycloak ... started` in the logs before proceeding.
+
+#### Step 6: Verify
+
+See [Post-Upgrade Verification](#post-upgrade-verification).
+
+### PostgreSQL Upgrade
+
+PostgreSQL upgrades are independent of the Keycloak operator version. Only upgrade
+PostgreSQL when the current version falls out of the
+[compatibility matrix](#version-compatibility-matrix) or when a security patch is
+needed.
+
+#### Minor version updates (e.g., 18.1 to 18.2)
+
+Minor updates are safe — they do not change the on-disk data format:
+
+```bash
+# Update the image tag in the StatefulSet manifest
+# Edit: prerequisites/keycloak/database/statefulset.yaml
+#   image: quay.io/sclorg/postgresql-18-c10s:latest
+
+oc apply -k prerequisites/keycloak/database/ -n keycloak
+oc rollout status statefulset/keycloak-database -n keycloak --timeout=300s
+```
+
+#### Major version updates (e.g., 15 to 18)
+
+Major PostgreSQL updates require a dump-and-restore because the on-disk format
+changes between major versions:
+
+1. Back up the database (see [Database Backup](#database-backup))
+2. Scale down Keycloak: `oc patch keycloak osac-keycloak -n keycloak --type=merge -p '{"spec":{"instances":0}}'`
+3. Delete the old StatefulSet and PVC
+4. Update the image in `statefulset.yaml` to the new major version
+5. Re-apply the database manifests: `oc apply -k prerequisites/keycloak/database/ -n keycloak`
+6. Restore the backup into the new database:
+   ```bash
+   KC_DB_PASS=$(oc get secret keycloak-db-credentials -n keycloak \
+       -o jsonpath='{.data.password}' | base64 -d)
+   oc exec -i keycloak-database-0 -n keycloak -- \
+       bash -c "PGPASSWORD='${KC_DB_PASS}' pg_restore -h localhost -U keycloak \
+       -d keycloak --clean --if-exists" < keycloak-backup-YYYYMMDD.dump
+   ```
+7. Scale Keycloak back up: `oc patch keycloak osac-keycloak -n keycloak --type=merge -p '{"spec":{"instances":1}}'`
+8. Verify (see [Post-Upgrade Verification](#post-upgrade-verification))
+
+---
+
+## Post-Upgrade Verification
+
+Run these checks after every upgrade.
+
+### 1. Keycloak CR health
+
+```bash
+oc get keycloak osac-keycloak -n keycloak \
+    -o jsonpath='{range .status.conditions[*]}{.type}={.status}{"\n"}{end}'
+```
+
+Expected output:
+
+```
+Ready=True
+HasErrors=False
+RollingUpdate=False
+```
+
+### 2. Token acquisition test
+
+```bash
+KC_SVC="https://keycloak.keycloak.svc.cluster.local"
+
+# From inside the cluster (e.g., oc debug or oc run):
+oc run token-test --rm -i --restart=Never --image=curlimages/curl -- \
+    -sk -X POST "${KC_SVC}/realms/osac/protocol/openid-connect/token" \
+    -d 'grant_type=password&client_id=admin-cli&username=tenant1_admin&password=foobar'
+```
+
+A successful response contains `"access_token":"eyJ..."`.
+
+### 3. Fulfillment controller connectivity
+
+```bash
+# Should show no auth-related errors in recent logs
+oc logs deploy/fulfillment-controller -n osac --tail=10 --since=5m \
+    | grep -i "error\|fail\|denied"
+```
+
+### 4. Realm integrity
+
+```bash
+KC_ROUTE="https://$(oc get route keycloak -n keycloak -o jsonpath='{.spec.host}')"
+
+# Get admin token (from inside cluster or with route access)
+ADMIN_TOKEN=$(curl -sk -X POST "${KC_SVC}/realms/master/protocol/openid-connect/token" \
+    -d 'grant_type=password&client_id=admin-cli' \
+    -d "username=$(oc get secret osac-keycloak-initial-admin -n keycloak -o jsonpath='{.data.username}' | base64 -d)" \
+    -d "password=$(oc get secret osac-keycloak-initial-admin -n keycloak -o jsonpath='{.data.password}' | base64 -d)" \
+    | grep -o '"access_token":"[^"]*"' | cut -d'"' -f4)
+
+# Check realm clients
+curl -sk -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    "${KC_SVC}/admin/realms/osac/clients" | python3 -m json.tool | grep clientId
+
+# Check realm users
+curl -sk -H "Authorization: Bearer ${ADMIN_TOKEN}" \
+    "${KC_SVC}/admin/realms/osac/users?max=50" | python3 -m json.tool | grep username
+```
+
+Verify that the expected clients (`osac-controller`, `admin-cli`, etc.) and users
+(`tenant1_admin`, `tenant1_user`, etc.) are present.
+
+---
+
+## Rollback Procedure
+
+### When to Roll Back
+
+Roll back if any of the following occur after an upgrade:
+
+- Keycloak CR is stuck in a non-Ready state for more than 10 minutes
+- Token acquisition fails (OIDC endpoints return errors)
+- Fulfillment controller logs show persistent authentication failures
+- Realm data is missing (clients, users, or groups disappeared)
+- Keycloak pod is in `CrashLoopBackOff` after the Liquibase migration
+
+### Full Rollback (Operator + Database)
+
+This procedure restores both the operator and the database to the pre-upgrade state.
+You need the backup file created during [Database Backup](#database-backup) and the
+previous operator version (the `startingCSV` value you recorded in the pre-upgrade
+checklist).
+
+#### Step 1: Scale down Keycloak
+
+Stop the Keycloak server to prevent further database changes:
+
+```bash
+oc patch keycloak osac-keycloak -n keycloak \
+    --type=merge -p '{"spec":{"instances":0}}'
+
+# Verify the pod is gone
+oc wait --for=delete pod/osac-keycloak-0 -n keycloak --timeout=120s
+```
+
+#### Step 2: Restore the database
+
+Keycloak's Liquibase migrations are forward-only — they add tables and foreign
+key constraints that `pg_restore --clean` cannot remove in dependency order. The
+only reliable restore method is to drop the entire database and recreate it:
+
+```bash
+# Copy backup into the container
+oc cp keycloak-backup-YYYYMMDD.dump \
+    keycloak/keycloak-database-0:/tmp/restore.dump -c server
+
+# Drop and recreate the database
+oc exec keycloak-database-0 -n keycloak -c server -- \
+    psql -U postgres -c "DROP DATABASE keycloak;"
+oc exec keycloak-database-0 -n keycloak -c server -- \
+    psql -U postgres -c "CREATE DATABASE keycloak OWNER keycloak;"
+
+# Restore from backup
+oc exec keycloak-database-0 -n keycloak -c server -- \
+    pg_restore -U postgres -d keycloak /tmp/restore.dump
+```
+
+Replace `YYYYMMDD` with the actual backup date.
+
+> **Why not `pg_restore --clean --if-exists`?** Keycloak upgrades add new
+> tables with foreign key constraints pointing to existing tables (e.g.,
+> `user_ver_credential` → `user_entity`). The `--clean` flag tries to drop
+> tables in dump order, but cannot drop `user_entity` because the new
+> (post-upgrade) FK constraints still reference it. This results in partial
+> restores with data integrity issues. A full `DROP DATABASE` avoids this
+> entirely.
+
+Verify the restore succeeded:
+
+```bash
+oc exec keycloak-database-0 -n keycloak -c server -- \
+    psql -U postgres -d keycloak -c "SELECT count(*) FROM realm;"
+```
+
+#### Step 3: Uninstall the current operator
+
+```bash
+# Get the current CSV name
+CURRENT_CSV=$(oc get csv -n keycloak -o jsonpath='{.items[0].metadata.name}')
+
+# Delete the OLM resources
+oc delete subscription keycloak-operator -n keycloak
+oc delete csv "${CURRENT_CSV}" -n keycloak
+oc delete installplan --all -n keycloak
+oc delete operatorgroup keycloak-operator -n keycloak
+```
+
+#### Step 4: Reinstall the previous version
+
+Edit `prerequisites/keycloak/operator.yaml` to use the previous `startingCSV`:
+
+```yaml
+spec:
+  startingCSV: keycloak-operator.v26.6.4   # previous version
+```
+
+Apply it:
+
+```bash
+oc apply -f prerequisites/keycloak/operator.yaml
+```
+
+#### Step 5: Approve the InstallPlan
+
+```bash
+# Wait for OLM to create the InstallPlan
+sleep 30
+PLAN_NAME=$(oc get installplan -n keycloak \
+    -o jsonpath='{.items[?(@.spec.approved==false)].metadata.name}')
+
+oc patch installplan "${PLAN_NAME}" -n keycloak \
+    --type=merge -p '{"spec":{"approved":true}}'
+
+# Wait for the CSV to be ready
+oc wait csv -n keycloak -l operators.coreos.com/keycloak-operator.keycloak= \
+    --for=jsonpath='{.status.phase}'=Succeeded --timeout=300s
+```
+
+#### Step 6: Scale Keycloak back up
+
+```bash
+oc patch keycloak osac-keycloak -n keycloak \
+    --type=merge -p '{"spec":{"instances":1}}'
+
+oc rollout status statefulset/osac-keycloak -n keycloak --timeout=600s
+```
+
+#### Step 7: Verify
+
+Run the full [Post-Upgrade Verification](#post-upgrade-verification) procedure.
+
+### PostgreSQL-Only Rollback
+
+If only the PostgreSQL image was changed (no operator/server upgrade), the rollback
+is simpler because no schema migrations are involved:
+
+```bash
+# Revert the image in statefulset.yaml to the previous version, then:
+oc apply -k prerequisites/keycloak/database/ -n keycloak
+oc rollout status statefulset/keycloak-database -n keycloak --timeout=300s
+```
+
+The data on the PVC is untouched — PostgreSQL minor versions use the same on-disk
+format.
+
+---
+
+## Version Compatibility Matrix
+
+The Keycloak operator pins the server version it manages. Each operator release
+includes a specific Keycloak server image. The table below shows PostgreSQL
+compatibility by Keycloak version:
+
+| Keycloak Version | Operator CSV | Supported PostgreSQL | Notes |
+|-----------------|-------------|---------------------|-------|
+| 26.7.x | `keycloak-operator.v26.7.0` | 14.x, 15.x, 16.x, 17.x, 18.x | Upgrade + rollback verified on edge-16 |
+| 26.6.x | `keycloak-operator.v26.6.4` | 14.x, 15.x, 16.x, 17.x, 18.x | Current OSAC version |
+| 26.5.x | `keycloak-operator.v26.5.x` | 14.x, 15.x, 16.x, 17.x, 18.x | PostgreSQL 13 dropped |
+| 26.4.x | `keycloak-operator.v26.4.x` | 13.x, 14.x, 15.x, 16.x, 17.x | Last version with PG 13 |
+
+**Important notes:**
+
+- PostgreSQL 13 reached end-of-life in November 2025. Keycloak 26.5+ dropped support
+  for it. If you are on PostgreSQL 13, upgrade PostgreSQL before upgrading Keycloak
+  past 26.4.
+- The OSAC deployment currently uses `quay.io/sclorg/postgresql-18-c10s:latest`
+  (PostgreSQL 18), which is compatible with all Keycloak 26.x versions.
+- Always check the [Keycloak release notes](https://www.keycloak.org/docs/latest/upgrading/)
+  for breaking changes before upgrading. Pay particular attention to the
+  "Migrating to ..." sections that document database schema changes.
+- The operator and server versions are coupled — you cannot run a 26.6 operator with a
+  26.4 server or vice versa.
+
+### Checking the upstream upgrade path
+
+Before upgrading, verify the upgrade path is valid:
+
+```bash
+# List available versions in the OLM channel
+oc get packagemanifest keycloak-operator -o jsonpath='{.status.channels[?(@.name=="fast")].entries[*].name}'
+```
+
+OLM enforces an upgrade graph — it will only offer valid upgrade paths. If a version
+is not listed as available from your current version, you may need to upgrade through
+intermediate versions.


### PR DESCRIPTION
## Summary

Two new guides for the operator-managed Keycloak deployment introduced in osac-project/osac-installer#459:

- **`guides/keycloak-configuration.md`** — Documents the OSAC realm (clients, scopes, groups, users), service integration (fulfillment-service auth, controller credentials, CLI), OLM deployment workflow, and BYO Keycloak support.

- **`guides/keycloak-upgrade-rollback.md`** — Full runbook covering:
  - Pre-upgrade checklist (version recording, health checks, storage)
  - Database backup via `pg_dump -U postgres` (unix socket — required for mTLS)
  - OLM operator upgrade with Manual InstallPlan approval
  - Rollback procedure (`DROP DATABASE` + `CREATE DATABASE` + `pg_restore`)
  - PostgreSQL major/minor version upgrades
  - Version compatibility matrix (verified v26.6.4 → v26.7.0 → rollback)

## Related

- Installer PR: osac-project/osac-installer#459

## Jira

https://redhat.atlassian.net/browse/OSAC-1580

## Test plan

- [x] Upgrade and rollback procedures verified on [edge-16](https://redhat.atlassian.net/browse/edge-16)
- [x] All commands tested against live operator-managed Keycloak deployment